### PR TITLE
Add structured logging, metrics, and audit modules

### DIFF
--- a/ai/audit_agent.py
+++ b/ai/audit_agent.py
@@ -1,0 +1,79 @@
+"""LLM-driven audit and mutation recommendation agent.
+
+Module purpose and system role:
+    - Parse logs and tests to produce audit summaries and mutation suggestions.
+    - Designed for offline use without external network calls.
+
+Integration points and dependencies:
+    - Reads ``AGENTS.md`` for current guidelines.
+    - Utilizes :class:`core.logger.StructuredLogger` for audit logging.
+
+Simulation/test hooks and kill conditions:
+    - Pure Python logic for unit tests; network access is not required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from core.logger import StructuredLogger
+
+LOGGER = StructuredLogger("audit_agent")
+
+
+class AuditAgent:
+    """Simple log-based audit analysis."""
+
+    def __init__(self, repo_root: str | None = None) -> None:
+        self.repo_root = Path(repo_root or Path(__file__).resolve().parents[1])
+
+    # ------------------------------------------------------------------
+    def read_agents_md(self) -> str:
+        path = self.repo_root / "AGENTS.md"
+        try:
+            return path.read_text()
+        except Exception:
+            return ""
+
+    # ------------------------------------------------------------------
+    def run_audit(self, log_paths: Iterable[str]) -> Dict[str, Any]:
+        events: List[Dict[str, Any]] = []
+        for p in log_paths:
+            try:
+                lines = Path(p).read_text().splitlines()
+                events.extend(json.loads(l) for l in lines if l.strip())
+            except Exception as exc:
+                LOGGER.log("log_read_error", strategy_id=p, error=str(exc), risk_level="low")
+        failures = [e for e in events if e.get("error")]
+        summary = {
+            "total_events": len(events),
+            "failures": len(failures),
+            "status": "fail" if failures else "pass",
+        }
+        LOGGER.log(
+            "audit_summary",
+            strategy_id=",".join(Path(p).stem for p in log_paths),
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            summary=summary,
+        )
+        return summary
+
+    # ------------------------------------------------------------------
+    def suggest_mutations(self, audit_summary: Dict[str, Any]) -> List[str]:
+        suggestions: List[str] = []
+        if audit_summary.get("failures", 0) > 0:
+            suggestions.append("Address logged errors and rerun tests.")
+        else:
+            suggestions.append("No failures detected.")
+        LOGGER.log(
+            "mutation_suggestion",
+            strategy_id="audit",
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            suggestions=suggestions,
+        )
+        return suggestions

--- a/ai/mutator/__init__.py
+++ b/ai/mutator/__init__.py
@@ -1,0 +1,4 @@
+"""Mutation utilities exports."""
+
+from .score import score_strategies
+from .prune import prune_strategies

--- a/ai/mutator/prune.py
+++ b/ai/mutator/prune.py
@@ -1,0 +1,53 @@
+"""Strategy pruning utilities.
+
+Module purpose and system role:
+    - Identify underperforming strategies for removal or deactivation.
+    - Logging of all prune decisions for AI audit and DRP tracing.
+
+Integration points and dependencies:
+    - Works with metrics produced by :mod:`ai.mutator.score` or strategy logs.
+    - Uses :class:`core.logger.StructuredLogger` for event logging.
+
+Simulation/test hooks and kill conditions:
+    - Designed for offline analysis; deterministic logic for unit tests.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from core.logger import StructuredLogger
+
+LOGGER = StructuredLogger("strategy_prune")
+
+
+PRUNE_THRESH = {
+    "pnl": 0.0,
+    "risk": 1.0,
+}
+
+
+def prune_strategies(metrics: Dict[str, Dict[str, Any]], audit_feedback: Dict[str, bool] | None = None) -> List[str]:
+    """Return list of strategy IDs flagged for pruning."""
+
+    flagged: List[str] = []
+    for sid, data in metrics.items():
+        pnl = float(data.get("pnl", 0.0))
+        risk = float(data.get("risk", 0.0))
+        chaos_fail = bool(data.get("chaos_fail", False))
+        audit_fail = False
+        if audit_feedback:
+            audit_fail = bool(audit_feedback.get(sid, False))
+
+        if pnl < PRUNE_THRESH["pnl"] or risk > PRUNE_THRESH["risk"] or chaos_fail or audit_fail:
+            flagged.append(sid)
+            LOGGER.log(
+                "prune_flag",
+                strategy_id=sid,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="high",
+                error=None,
+                info={"pnl": pnl, "risk": risk, "chaos_fail": chaos_fail, "audit_fail": audit_fail},
+            )
+    return flagged

--- a/ai/mutator/score.py
+++ b/ai/mutator/score.py
@@ -1,0 +1,95 @@
+"""Strategy scoring utilities.
+
+Module purpose and system role:
+    - Evaluate performance metrics for each strategy and produce a ranking.
+    - Emit scores to JSON and structured logs for later mutation.
+
+Integration points and dependencies:
+    - Consumes metrics dictionaries (e.g., from ``core.metrics`` or strategy logs).
+    - Uses :class:`core.logger.StructuredLogger` for logging.
+
+Simulation/test hooks and kill conditions:
+    - Pure-python; deterministic for unit and chaos tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from statistics import mean, stdev
+from typing import Any, Dict, List
+
+from core.logger import StructuredLogger
+
+LOGGER = StructuredLogger("strategy_score")
+
+
+def score_strategies(metrics: Dict[str, Dict[str, Any]], output_path: str = "logs/strategy_scores.json") -> List[Dict[str, Any]]:
+    """Compute scores for strategies based on provided ``metrics``.
+
+    Parameters
+    ----------
+    metrics:
+        Mapping of strategy_id to metric dictionary. Expected keys include
+        ``pnl``, ``returns``, ``risk``, ``volatility``, ``wins``, ``losses``,
+        ``latencies``, and ``opportunities``.
+    output_path:
+        JSON file path where ranked scores will be written.
+    """
+
+    ranking: List[Dict[str, Any]] = []
+    for sid, data in metrics.items():
+        pnl = float(data.get("pnl", 0.0))
+        returns = data.get("returns", [pnl])
+        sharpe = 0.0
+        if isinstance(returns, list) and len(returns) > 1:
+            try:
+                sharpe = mean(returns) / stdev(returns)
+            except Exception:
+                sharpe = 0.0
+        risk = float(data.get("risk", 0.0))
+        volatility = float(data.get("volatility", 0.0))
+        wins = int(data.get("wins", 0))
+        losses = int(data.get("losses", 0))
+        win_rate = wins / max(wins + losses, 1)
+        latencies = data.get("latencies", [])
+        avg_latency = mean(latencies) if isinstance(latencies, list) and latencies else 0.0
+        opportunities = int(data.get("opportunities", 0))
+        density = opportunities / max(len(latencies), 1)
+
+        score = (
+            pnl
+            + sharpe * 100
+            + win_rate * 10
+            - risk * 100
+            - volatility * 10
+            - avg_latency * 0.1
+            + density * 5
+        )
+        ranking.append(
+            {
+                "strategy": sid,
+                "score": score,
+                "pnl": pnl,
+                "sharpe": sharpe,
+                "risk": risk,
+                "volatility": volatility,
+                "win_rate": win_rate,
+                "avg_latency": avg_latency,
+                "opportunity_density": density,
+            }
+        )
+
+    ranking.sort(key=lambda x: x["score"], reverse=True)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as fh:
+        json.dump(ranking, fh, indent=2)
+    LOGGER.log(
+        "strategy_scores",
+        strategy_id="scoring",
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        scores=ranking,
+    )
+    return ranking

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,0 +1,82 @@
+"""Structured JSON logger for MEV-OG modules.
+
+Module purpose and system role:
+    - Provide production-grade logging with consistent schema.
+    - Emits JSON lines for Prometheus and AI audit ingestion.
+
+Integration points and dependencies:
+    - Minimal dependencies (standard library only).
+    - Other modules instantiate ``StructuredLogger`` to record events.
+
+Simulation/test hooks and kill conditions:
+    - Hooks allow test suites and audit agents to trace log output.
+    - Designed for offline use; no network dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+
+_HOOKS: List[Callable[[Dict[str, Any]], None]] = []
+
+
+def register_hook(func: Callable[[Dict[str, Any]], None]) -> None:
+    """Register ``func`` to receive every log entry."""
+    _HOOKS.append(func)
+
+
+class StructuredLogger:
+    """Write structured JSON logs to file and broadcast to hooks."""
+
+    def __init__(self, module: str, log_file: str | None = None) -> None:
+        self.module = module
+        if log_file is None:
+            env_var = f"{module.upper()}_LOG"
+            log_file = os.getenv(env_var, f"logs/{module}.json")
+        self.path = Path(log_file)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def log(
+        self,
+        event: str,
+        *,
+        tx_id: str = "",
+        strategy_id: str = "",
+        mutation_id: str = "",
+        risk_level: str = "",
+        error: str | None = None,
+        **extra: Any,
+    ) -> None:
+        """Append log entry to file and send to hooks."""
+
+        entry: Dict[str, Any] = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "event": event,
+            "module": self.module,
+            "tx_id": tx_id,
+            "strategy_id": strategy_id,
+            "mutation_id": mutation_id,
+            "risk_level": risk_level,
+            "error": error,
+        }
+        entry.update(extra)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a") as fh:
+            fh.write(json.dumps(entry) + "\n")
+        for hook in list(_HOOKS):
+            try:
+                hook(entry)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    def trace(self, message: str, **kw: Any) -> None:
+        """Alias for :func:`log` used for verbose tracing."""
+
+        self.log(message, **kw)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,97 @@
+"""Prometheus-style metrics endpoint for MEV-OG.
+
+Module purpose and system role:
+    - Track strategy performance and system health metrics.
+    - Provide an HTTP ``/metrics`` endpoint consumable by Prometheus.
+
+Integration points and dependencies:
+    - Uses ``http.server`` from the standard library; no external deps.
+    - Strategies call update functions to modify metric counters.
+
+Simulation/test hooks and kill conditions:
+    - Designed for forked and unit test environments.
+    - Lightweight server can be started and stopped in tests.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from statistics import mean
+from typing import Dict, List, cast
+
+
+_METRICS: Dict[str, List[float] | float | int] = {
+    "opportunities": 0,
+    "fails": 0,
+    "pnl": 0.0,
+    "spreads": [],
+    "latencies": [],
+    "alert_count": 0,
+}
+_LOCK = threading.Lock()
+
+
+# ----------------------------------------------------------------------
+# Metric update helpers
+# ----------------------------------------------------------------------
+
+def record_opportunity(spread: float, pnl: float, latency: float) -> None:
+    with _LOCK:
+        _METRICS["opportunities"] += 1
+        _METRICS["pnl"] += pnl
+        cast(list, _METRICS["spreads"]).append(spread)  # type: ignore[arg-type]
+        cast(list, _METRICS["latencies"]).append(latency)  # type: ignore[arg-type]
+
+
+def record_fail() -> None:
+    with _LOCK:
+        _METRICS["fails"] += 1
+
+
+def record_alert() -> None:
+    with _LOCK:
+        _METRICS["alert_count"] += 1
+
+
+# ----------------------------------------------------------------------
+# Metrics server
+# ----------------------------------------------------------------------
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # pragma: no cover - trivial
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        with _LOCK:
+            avg_spread = mean(_METRICS["spreads"]) if _METRICS["spreads"] else 0.0
+            avg_latency = mean(_METRICS["latencies"]) if _METRICS["latencies"] else 0.0
+            body = (
+                f"opportunities_total {_METRICS['opportunities']}\n"
+                f"fails_total {_METRICS['fails']}\n"
+                f"pnl_total {_METRICS['pnl']}\n"
+                f"avg_spread {avg_spread}\n"
+                f"avg_latency_seconds {avg_latency}\n"
+                f"alert_count {_METRICS['alert_count']}\n"
+            ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class MetricsServer:
+    """Background metrics HTTP server."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8000) -> None:
+        self.server = HTTPServer((host, port), _Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.server.shutdown()
+        self.thread.join()

--- a/tests/test_audit_agent.py
+++ b/tests/test_audit_agent.py
@@ -1,0 +1,22 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import json
+from pathlib import Path
+
+from ai.audit_agent import AuditAgent
+from core.logger import StructuredLogger
+
+
+def test_audit_summary(tmp_path):
+    log_file = tmp_path / "strategy.json"
+    logger = StructuredLogger("test_strategy", log_file=str(log_file))
+    logger.log("run", error=None)
+    logger.log("fail", error="oops")
+
+    agent = AuditAgent(repo_root=str(Path(__file__).resolve().parents[1]))
+    summary = agent.run_audit([str(log_file)])
+    assert summary["failures"] == 1
+    suggestions = agent.suggest_mutations(summary)
+    assert suggestions
+

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,26 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import json
+from pathlib import Path
+
+from core.logger import StructuredLogger, register_hook
+
+
+def test_structured_logging(tmp_path):
+    log_file = tmp_path / "log.json"
+    logger = StructuredLogger("test_mod", log_file=str(log_file))
+    captured = []
+
+    def hook(entry):
+        captured.append(entry)
+
+    register_hook(hook)
+    logger.log(
+        "event", tx_id="1", strategy_id="s", mutation_id="m", risk_level="low"
+    )
+
+    data = [json.loads(l) for l in log_file.read_text().splitlines()]
+    assert data[0]["module"] == "test_mod"
+    assert data[0]["event"] == "event"
+    assert captured and captured[0]["tx_id"] == "1"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,26 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import urllib.request
+
+opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+from core import metrics
+
+
+def test_metrics_server(tmp_path):
+    srv = metrics.MetricsServer(port=0)
+    srv.start()
+
+    metrics.record_opportunity(0.1, 5.0, 0.5)
+    metrics.record_fail()
+    metrics.record_alert()
+
+    host, port = srv.server.server_address
+    url = f"http://{host}:{port}/metrics"
+    data = opener.open(url).read().decode()
+    srv.stop()
+
+    assert "opportunities_total 1" in data
+    assert "fails_total 1" in data
+    assert "alert_count 1" in data

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,0 +1,35 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai.mutator import score_strategies, prune_strategies
+
+
+def test_score_and_prune(tmp_path):
+    metrics = {
+        "stratA": {
+            "pnl": 10,
+            "returns": [1, 2, 3],
+            "risk": 0.5,
+            "volatility": 0.2,
+            "wins": 3,
+            "losses": 1,
+            "latencies": [0.1, 0.2],
+            "opportunities": 4,
+        },
+        "stratB": {
+            "pnl": -5,
+            "risk": 1.5,
+            "volatility": 0.5,
+            "wins": 0,
+            "losses": 2,
+            "latencies": [1.0],
+            "opportunities": 1,
+            "chaos_fail": True,
+        },
+    }
+    scores = score_strategies(metrics, output_path=str(tmp_path / "scores.json"))
+    assert scores[0]["strategy"] == "stratA"
+
+    flagged = prune_strategies(metrics, audit_feedback={"stratB": True})
+    assert "stratB" in flagged
+    assert "stratA" not in flagged


### PR DESCRIPTION
## Summary
- add structured JSON logger and Prometheus metrics server
- score and prune strategies via new mutator utilities
- implement audit agent to parse logs and produce suggestions
- create tests for telemetry and audit modules

## Testing
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: No such file or directory)*
- `bash scripts/export_state.sh --dry-run`