### PR TITLE
v3.3-batch3-datetime-finalfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ MEV-OG is an AI-native, adversarial crypto trading system built to compound $5K 
 - **Simulation/Test:** Foundry/Hardhat, Anvil forked-mainnet, chaos sim
 - **Monitoring:** Prometheus, Grafana, Discord/Telegram bot alerts
 - **AI/LLM:** Codex (codegen, mutation), GPT (audit, anomaly detection)
+- **Online Audit:** `AuditAgent.run_online_audit` uses OpenAI GPT when `OPENAI_API_KEY` is set
 - **Security:** Kill switch, circuit breakers, replay defense, key rotation
 - **Recovery:** DRP + 1-hour restore snapshot from logs/state
 

--- a/core/logger.py
+++ b/core/logger.py
@@ -16,7 +16,7 @@ Simulation/test hooks and kill conditions:
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List
@@ -56,7 +56,7 @@ class StructuredLogger:
         """Append log entry to file and send to hooks."""
 
         entry: Dict[str, Any] = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "event": event,
             "module": self.module,
             "tx_id": tx_id,

--- a/core/tx_engine/kill_switch.py
+++ b/core/tx_engine/kill_switch.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 ENV_VAR = "KILL_SWITCH"
@@ -50,7 +50,7 @@ def record_kill_event(origin: str) -> None:
     source = "env" if os.getenv(ENV_VAR) == "1" else "file" if _flag_file().exists() else "unknown"
     event = {
         "kill_event": True,
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "triggered_by": source,
         "origin_module": origin,
     }

--- a/core/tx_engine/nonce_manager.py
+++ b/core/tx_engine/nonce_manager.py
@@ -7,7 +7,7 @@ Module purpose and system role:
 
 Integration points and dependencies:
 - Expects a Web3-like object for RPC calls.
-- Writes cache to ``/state/nonce_cache.json`` and logs to ``logs/nonce_log.json``.
+ - Writes cache to ``state/nonce_cache.json`` and logs to ``logs/nonce_log.json``.
 
 Simulation/test hooks and kill conditions:
 - Designed for forked-mainnet simulation to validate nonce drift handling.
@@ -15,7 +15,7 @@ Simulation/test hooks and kill conditions:
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import threading
 from typing import Dict, Optional, Any
@@ -25,7 +25,7 @@ class NonceManager:
     def __init__(
         self,
         web3: Optional[Any] = None,
-        cache_file: str = "/state/nonce_cache.json",
+        cache_file: str = "state/nonce_cache.json",
         log_file: str = "logs/nonce_log.json",
     ) -> None:
         self.web3 = web3
@@ -73,7 +73,7 @@ class NonceManager:
             "address": address,
             "on_chain_nonce": on_chain_nonce,
             "local_nonce": local_nonce,
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "source": source,
         }
         with self.log_path.open("a") as fh:

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -20,7 +20,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from statistics import mean
@@ -131,7 +131,7 @@ class CrossDomainArb:
     # ------------------------------------------------------------------
     def _record(self, domain: str, data: PriceData, opportunity: bool, spread: float, action: str = "", tx_id: str = "") -> None:
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "domain": domain,
             "price": data.price,
             "opportunity": opportunity,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 import json
 from pathlib import Path
+from datetime import datetime
 
 from core.logger import StructuredLogger, register_hook
 
@@ -24,3 +25,6 @@ def test_structured_logging(tmp_path):
     assert data[0]["module"] == "test_mod"
     assert data[0]["event"] == "event"
     assert captured and captured[0]["tx_id"] == "1"
+    ts = data[0]["timestamp"]
+    dt = datetime.fromisoformat(ts)
+    assert dt.tzinfo is not None


### PR DESCRIPTION
## Summary
- enforce timezone import with `timezone.utc`
- switch nonce cache path to relative `state/nonce_cache.json`
- adjust all timestamp calls to use timezone-aware now()

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: no such file)*
- `scripts/export_state.sh --dry-run`