### PR TITLE
v3.2-datetime-utc-fix

### DIFF
--- a/core/tx_engine/kill_switch.py
+++ b/core/tx_engine/kill_switch.py
@@ -49,8 +49,8 @@ def record_kill_event(origin: str) -> None:
     """Append a structured kill event to the log file."""
     source = "env" if os.getenv(ENV_VAR) == "1" else "file" if _flag_file().exists() else "unknown"
     event = {
-        "kill_event": True
-        "timestamp": datetime.now(datetime.UTC).isoformat(),
+        "kill_event": True,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "triggered_by": source,
         "origin_module": origin,
     }


### PR DESCRIPTION
## Summary
- fix kill switch timestamp logic to use `timezone.utc`

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: no such file)*
- `scripts/export_state.sh --dry-run`