### PR TITLE
Add L3 app rollup MEV strategy with tests and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,12 @@ Every PR or batch/module must pass:
 - Rollback: `bash scripts/rollback.sh --archive=<path>`
 - Mutation cycle: `python ai/mutator/main.py --logs-dir logs`
 
+### l3_app_rollup_mev Runbook
+- Fork simulation: `bash scripts/simulate_fork.sh --target=strategies/l3_app_rollup_mev`
+- Export state: `bash scripts/export_state.sh`
+- Rollback: `bash scripts/rollback.sh --archive=<path>`
+- Mutation cycle: `python ai/mutator/main.py --logs-dir logs`
+
 ---
 
 ## Codex Behavior Log

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ MEV-OG is an AI-native, adversarial crypto trading system built to compound $5K 
 |--------|--------|-------------|
 | `strategies/cross_domain_arb` | 🚧 In progress | Cross-rollup + L1-L2 arbitrage execution bot |
 | `strategies/cross_rollup_superbot` | 🚧 In progress | Advanced cross-rollup sandwich/arb with DRP and mutation |
+| `strategies/l3_app_rollup_mev` | 🚧 In progress | L3/app-rollup sandwiches and bridge-race MEV |
 | `infra/sim_harness` | ✅ | Simulates forks, chaos, and tx latency/failure |
 | `ai/mutator` | ✅ | Self-prunes, mutates, and re-tunes strategies |
 | `ai/mutator/main.py` | ✅ | Orchestrates AI mutation cycles and audit-driven promotion |
@@ -163,6 +164,20 @@ bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
 ```
 
+### l3_app_rollup_mev Runbook
+
+```bash
+# Start metrics server
+python -m core.metrics --port $METRICS_PORT &
+# Run fork simulation
+bash scripts/simulate_fork.sh --target=strategies/l3_app_rollup_mev
+# Run a mutation and audit cycle
+python ai/mutator/main.py --logs-dir logs
+# Export DRP snapshot and rollback if needed
+bash scripts/export_state.sh
+bash scripts/rollback.sh --archive=<exported-archive>
+```
+
 ### AI Mutation Workflow
 
 1. Collect logs from all strategies.
@@ -180,6 +195,9 @@ Logs must include `timestamp`, `tx_id`, `strategy_id`, `mutation_id`,
 `cross_rollup_superbot` logs to `logs/cross_rollup_superbot.json` and shares the
 common error log `logs/errors.log`. Metrics are scraped from the same
 `/metrics` endpoint.
+
+`l3_app_rollup_mev` logs to `logs/l3_app_rollup_mev.json` and shares the common
+error log `logs/errors.log`. Metrics use the global `/metrics` endpoint.
 
 ## Mutation Workflow
 

--- a/core/oracles/__init__.py
+++ b/core/oracles/__init__.py
@@ -1,5 +1,6 @@
 """Oracle utilities for on-chain data access."""
 
 from .uniswap_feed import UniswapV3Feed, PriceData
+from .intent_feed import IntentFeed, IntentData
 
-__all__ = ["UniswapV3Feed", "PriceData"]
+__all__ = ["UniswapV3Feed", "PriceData", "IntentFeed", "IntentData"]

--- a/core/oracles/intent_feed.py
+++ b/core/oracles/intent_feed.py
@@ -1,0 +1,55 @@
+"""Intent feed for L3/app-rollup transactions.
+
+This module fetches open intents from a configurable HTTP endpoint. The
+endpoint is expected to return JSON lists of intents with minimal fields. The
+feed is used in tests with mocked responses and can be pointed at a live
+service in production.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+from dataclasses import dataclass
+from typing import List
+
+from core.logger import log_error
+
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - allow missing dependency
+    requests = None  # type: ignore
+
+
+@dataclass
+class IntentData:
+    intent_id: str
+    domain: str
+    action: str
+    price: float
+
+
+class IntentFeed:
+    """Fetch intent data from ``INTENT_FEED_URL``."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or os.getenv("INTENT_FEED_URL", "http://localhost:9000")
+
+    def fetch_intents(self, domain: str) -> List[IntentData]:
+        if requests is None:
+            raise RuntimeError("requests package required")
+        url = f"{self.base_url}/{domain}/intents"
+        try:  # pragma: no cover - network
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # pragma: no cover - network
+            log_error("IntentFeed", str(exc), event="fetch_intents", domain=domain)
+            raise
+        intents = []
+        for item in data:
+            try:
+                intents.append(IntentData(**item))
+            except Exception as exc:
+                log_error("IntentFeed", f"bad intent: {exc}", event="parse", domain=domain)
+        return intents

--- a/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
+++ b/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
@@ -1,0 +1,54 @@
+"""Fork simulation for L3AppRollupMEV."""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from strategies.l3_app_rollup_mev.strategy import (
+    L3AppRollupMEV,
+    PoolConfig,
+    BridgeConfig,
+)
+
+try:  # pragma: no cover
+    from web3 import Web3
+    from web3.middleware import geth_poa_middleware
+except Exception:  # pragma: no cover
+    raise SystemExit("web3 required for fork simulation")
+
+FORK_BLOCK = int(os.getenv("FORK_BLOCK", "19741234"))
+RPC_L2 = os.getenv("RPC_ARBITRUM_URL", "http://localhost:8547")
+RPC_L3 = os.getenv("RPC_ZKSYNC_URL", "http://localhost:8550")
+
+POOLS = {
+    "l2": PoolConfig(os.getenv("POOL_ARBITRUM", "0xb3f8e4262c5bfcc0a304143cfb33c7a9a64e0fe0"), "arbitrum"),
+    "l3": PoolConfig(os.getenv("POOL_ZKSYNC", "0x0000000000000000000000000000000000000000"), "zksync"),
+}
+
+BRIDGES = {
+    ("zksync", "arbitrum"): BridgeConfig(0.0005, latency_sec=10),
+}
+
+
+def main() -> None:  # pragma: no cover
+    w3 = Web3(Web3.HTTPProvider(RPC_L2))
+    w3.middleware_onion.add(geth_poa_middleware)
+    if w3.eth.block_number < FORK_BLOCK:
+        raise SystemExit("RPC must be forked at or after block %s" % FORK_BLOCK)
+    strat = L3AppRollupMEV(POOLS, BRIDGES)
+    found = False
+    for _ in range(10):
+        result = strat.run_once()
+        if result and result.get("opportunity"):
+            found = True
+            break
+        time.sleep(1)
+    assert found, "no L3 opportunity detected in window"
+    Path("logs/sim_complete.txt").write_text("done")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/strategies/l3_app_rollup_mev/__init__.py
+++ b/strategies/l3_app_rollup_mev/__init__.py
@@ -1,0 +1,5 @@
+"""L3/app-rollup MEV strategy package."""
+
+from .strategy import L3AppRollupMEV, PoolConfig, BridgeConfig
+
+__all__ = ["L3AppRollupMEV", "PoolConfig", "BridgeConfig"]

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -1,0 +1,297 @@
+"""L3/app-rollup MEV strategy leveraging sandwich and bridge race edges.
+
+This module scans L3 rollups for price discrepancies relative to L2/L1 pools
+and monitors intent feeds for bridge transactions that can be frontrun.  It
+supports runtime mutation, DRP snapshot/restore and kill switch integration.
+
+Integration points and dependencies:
+    - :class:`core.oracles.uniswap_feed.UniswapV3Feed` for pool pricing.
+    - :class:`core.oracles.intent_feed.IntentFeed` for intent data.
+    - :class:`core.tx_engine.TransactionBuilder` and :class:`core.tx_engine.NonceManager` for dispatch.
+    - Kill switch utilities to abort on demand.
+
+Simulation/test hooks and kill conditions:
+    - Designed for forked-mainnet simulation via ``infra/sim_harness``.
+    - Snapshot and restore functions persist price and bridge state.
+    - Aborts immediately if the kill switch is triggered.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from core.logger import StructuredLogger, log_error
+from core import metrics
+from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
+from core.oracles.intent_feed import IntentFeed, IntentData
+from core.tx_engine.builder import HexBytes, TransactionBuilder
+from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+
+LOG_FILE = Path(os.getenv("L3_APP_ROLLUP_LOG", "logs/l3_app_rollup_mev.json"))
+LOG = StructuredLogger("l3_app_rollup_mev", log_file=str(LOG_FILE))
+STRATEGY_ID = "l3_app_rollup_mev"
+
+
+@dataclass
+class PoolConfig:
+    """Configuration for monitored pools."""
+
+    pool: str
+    domain: str
+
+
+@dataclass
+class BridgeConfig:
+    """Bridge parameters between domains."""
+
+    cost: float
+    latency_sec: int = 0
+
+
+class L3AppRollupMEV:
+    """Main strategy class handling sandwich and bridge-race opportunities."""
+
+    DEFAULT_THRESHOLD = 0.003
+
+    def __init__(
+        self,
+        pools: Dict[str, PoolConfig],
+        bridge_costs: Dict[Tuple[str, str], BridgeConfig],
+        *,
+        threshold: float | None = None,
+        edges_enabled: Optional[Dict[str, bool]] = None,
+    ) -> None:
+        self.feed = UniswapV3Feed()
+        self.intent_feed = IntentFeed()
+        self.pools = pools
+        self.bridge_costs = bridge_costs
+        self.threshold = threshold if threshold is not None else self.DEFAULT_THRESHOLD
+        self.edges_enabled = edges_enabled or {
+            "l3_sandwich": True,
+            "bridge_race": True,
+        }
+        self.last_prices: Dict[str, float] = {}
+        self.pending_bridges: Dict[str, int] = {}
+        self.failed_pools: Dict[str, int] = {}
+        self.max_failures = 3
+
+        w3 = self.feed.web3s.get("ethereum") if self.feed.web3s else None
+        self.nonce_manager = NonceManager(w3)
+        self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
+        self.executor = os.getenv("L3_APP_EXECUTOR", "0x0000000000000000000000000000000000000000")
+        self.sample_tx = HexBytes(b"\x01")
+
+    # ------------------------------------------------------------------
+    def snapshot(self, path: str) -> None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as fh:
+            json.dump({"last_prices": self.last_prices, "pending_bridges": self.pending_bridges}, fh)
+
+    def restore(self, path: str) -> None:
+        if os.path.exists(path):
+            data = json.loads(Path(path).read_text())
+            self.last_prices = data.get("last_prices", {})
+            self.pending_bridges = data.get("pending_bridges", {})
+
+    # ------------------------------------------------------------------
+    def _record(
+        self,
+        domain: str,
+        data: PriceData,
+        opportunity: bool,
+        spread: float,
+        action: str = "",
+        tx_id: str = "",
+    ) -> None:
+        LOG.log(
+            "price",
+            tx_id=tx_id,
+            strategy_id=STRATEGY_ID,
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            domain=domain,
+            price=data.price,
+            block=data.block,
+            block_age=data.block_age,
+            opportunity=opportunity,
+            spread=spread,
+            action=action,
+        )
+
+    # ------------------------------------------------------------------
+    def _compute_profit(self, buy: str, sell: str, prices: Dict[str, float]) -> float:
+        price_buy = prices[buy]
+        price_sell = prices[sell]
+        spread = (price_sell - price_buy) / price_buy
+        fee = self.bridge_costs.get((buy, sell), BridgeConfig(0.0)).cost
+        return (spread - fee)
+
+    def _detect_sandwich(self, prices: Dict[str, float]) -> Optional[Dict[str, object]]:
+        if not self.edges_enabled.get("l3_sandwich", True):
+            return None
+        domains = list(prices.keys())
+        if len(domains) < 2:
+            return None
+        buy = min(domains, key=lambda d: prices[d])
+        sell = max(domains, key=lambda d: prices[d])
+        spread = (prices[sell] - prices[buy]) / prices[buy]
+        if spread < self.threshold:
+            return None
+        profit = self._compute_profit(buy, sell, prices)
+        if profit <= 0:
+            return None
+        action = f"l3_sandwich:{buy}->{sell}"
+        return {"opportunity": True, "spread": spread, "profit": profit, "action": action, "buy": buy, "sell": sell}
+
+    def _detect_bridge_race(self, prices: Dict[str, float]) -> Optional[Dict[str, object]]:
+        if not self.edges_enabled.get("bridge_race", True):
+            return None
+        for (src, dst), cfg in self.bridge_costs.items():
+            if src not in prices or dst not in prices:
+                continue
+            intents: list[IntentData]
+            try:
+                intents = self.intent_feed.fetch_intents(src)
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"intent fetch: {exc}", event="intent_fetch", domain=src)
+                return None
+            if not intents:
+                continue
+            # Assume any intent implies funds bridging from src to dst
+            spread = (prices[dst] - prices[src]) / prices[src]
+            if spread < self.threshold:
+                continue
+            latency = cfg.latency_sec
+            if latency > int(os.getenv("BRIDGE_LATENCY_MAX", "30")):
+                continue
+            profit = self._compute_profit(src, dst, prices)
+            if profit <= 0:
+                continue
+            action = f"bridge_race:{src}->{dst}"
+            return {"opportunity": True, "spread": spread, "profit": profit, "action": action, "buy": src, "sell": dst}
+        return None
+
+    def _bundle_and_send(self, action: str) -> str:
+        tx_hash = self.tx_builder.send_transaction(
+            self.sample_tx,
+            self.executor,
+            strategy_id=STRATEGY_ID,
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+        )
+        return str(tx_hash)
+
+    # ------------------------------------------------------------------
+    def run_once(self) -> Optional[Dict[str, object]]:
+        if kill_switch_triggered():
+            record_kill_event(STRATEGY_ID)
+            LOG.log(
+                "killed",
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="high",
+            )
+            return None
+
+        price_data: Dict[str, PriceData] = {}
+        for label, cfg in self.pools.items():
+            if self.failed_pools.get(label, 0) >= self.max_failures:
+                continue
+            try:
+                data = self.feed.fetch_price(cfg.pool, cfg.domain)
+            except Exception as exc:
+                log_error(STRATEGY_ID, str(exc), event="price_fetch", domain=cfg.domain)
+                self.failed_pools[label] = self.failed_pools.get(label, 0) + 1
+                metrics.record_fail()
+                return None
+            price_data[label] = data
+            self.last_prices[label] = data.price
+            self._record(cfg.domain, data, False, 0.0)
+
+        if not price_data:
+            return None
+
+        if any(d.block_age > int(os.getenv("PRICE_FRESHNESS_SEC", "30")) for d in price_data.values()):
+            log_error(STRATEGY_ID, "stale price detected", event="stale_price")
+            metrics.record_fail()
+            return None
+
+        prices = {k: d.price for k, d in price_data.items()}
+        opp = self._detect_sandwich(prices)
+        if opp is None:
+            opp = self._detect_bridge_race(prices)
+
+        if opp:
+            metrics.record_opportunity(float(opp["spread"]), float(opp["profit"]), 0.0)
+            pre = os.getenv("L3_APP_STATE_PRE", "state/l3_app_pre.json")
+            post = os.getenv("L3_APP_STATE_POST", "state/l3_app_post.json")
+            tx_pre = os.getenv("L3_APP_TX_PRE", "state/l3_app_tx_pre.json")
+            tx_post = os.getenv("L3_APP_TX_POST", "state/l3_app_tx_post.json")
+            for p in (pre, post, tx_pre, tx_post):
+                Path(p).parent.mkdir(parents=True, exist_ok=True)
+            self.snapshot(pre)
+            self.tx_builder.snapshot(tx_pre)
+            tx_id = self._bundle_and_send(str(opp["action"]))
+            self.tx_builder.snapshot(tx_post)
+            self.snapshot(post)
+            for label, data in price_data.items():
+                self._record(
+                    self.pools[label].domain,
+                    data,
+                    True,
+                    float(opp["spread"]),
+                    str(opp["action"]),
+                    tx_id=tx_id,
+                )
+        else:
+            metrics.record_fail()
+
+        return opp
+
+    # ------------------------------------------------------------------
+    def mutate(self, params: Dict[str, object]) -> None:
+        if "threshold" in params:
+            try:
+                self.threshold = float(params["threshold"])
+                LOG.log(
+                    "mutate",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    param="threshold",
+                    value=self.threshold,
+                )
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")
+        if "bridge_costs" in params:
+            try:
+                for k, v in params["bridge_costs"].items():
+                    pair = tuple(k.split("->"))
+                    self.bridge_costs[pair] = BridgeConfig(**v)
+                LOG.log(
+                    "mutate",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    param="bridge_costs",
+                )
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"mutate bridge_costs: {exc}", event="mutate_error")
+        if "edges_enabled" in params:
+            try:
+                self.edges_enabled.update({str(k): bool(v) for k, v in params["edges_enabled"].items()})
+                LOG.log(
+                    "mutate",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    param="edges_enabled",
+                )
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"mutate edges_enabled: {exc}", event="mutate_error")
+

--- a/tests/test_l3_app_rollup_mev.py
+++ b/tests/test_l3_app_rollup_mev.py
@@ -1,0 +1,153 @@
+import os
+import json
+import tempfile
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from strategies.l3_app_rollup_mev import L3AppRollupMEV, PoolConfig, BridgeConfig
+from core.oracles.uniswap_feed import PriceData
+from core.oracles.intent_feed import IntentData
+
+
+class DummyPool:
+    def __init__(self, price):
+        self._price = price
+
+    class functions:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def slot0(self):
+            return lambda: (self.outer._price, 0, 0, 0, 0, 0, False)
+
+        def token0(self):
+            return lambda: "0x0"
+
+        def token1(self):
+            return lambda: "0x1"
+
+    def __getattr__(self, item):
+        return getattr(self.functions(self), item)
+
+
+class DummyEth:
+    def __init__(self, price):
+        self.contract_obj = DummyPool(price)
+
+    def contract(self, address, abi):
+        return self.contract_obj
+
+    def get_block(self, block):
+        return type("B", (), {"number": 1, "timestamp": 1})
+
+    def get_transaction_count(self, address):
+        return 0
+
+    def estimate_gas(self, tx):
+        return 21000
+
+    class account:
+        @staticmethod
+        def decode_transaction(tx):
+            return {}
+
+
+class DummyWeb3:
+    def __init__(self, price):
+        self.eth = DummyEth(price)
+
+
+class DummyFeed:
+    def __init__(self, prices):
+        self.prices = prices
+        self.web3s = {d: DummyWeb3(p) for d, p in prices.items()}
+
+    def fetch_price(self, pool, domain):
+        if isinstance(self.prices[domain], Exception):
+            raise self.prices[domain]
+        price = self.prices[domain]
+        return PriceData(price, pool, 1, 1, 0)
+
+
+class DummyIntentFeed:
+    def __init__(self, intents):
+        self.intents = intents
+
+    def fetch_intents(self, domain):
+        data = self.intents.get(domain)
+        if isinstance(data, Exception):
+            raise data
+        return [IntentData(**i) for i in data]
+
+
+def setup_strat(threshold=0.01):
+    pools = {
+        "arbitrum": PoolConfig("0xpool", "arbitrum"),
+        "zksync": PoolConfig("0xpool", "zksync"),
+    }
+    bridges = {("zksync", "arbitrum"): BridgeConfig(0.0001, latency_sec=10)}
+    strat = L3AppRollupMEV(pools, bridges, threshold=threshold)
+    return strat
+
+
+def test_l3_sandwich_opportunity():
+    strat = setup_strat(threshold=0.01)
+    strat.feed = DummyFeed({"arbitrum": 100, "zksync": 102})
+    strat.intent_feed = DummyIntentFeed({"zksync": []})
+    strat.tx_builder.web3 = strat.feed.web3s["arbitrum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["arbitrum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+    result = strat.run_once()
+    assert result and result["opportunity"]
+
+
+def test_bridge_race_opportunity():
+    strat = setup_strat(threshold=0.001)
+    strat.feed = DummyFeed({"arbitrum": 101, "zksync": 100})
+    strat.intent_feed = DummyIntentFeed({"zksync": [{"intent_id": "1", "domain": "zksync", "action": "bridge", "price": 101}]})
+    strat.edges_enabled["l3_sandwich"] = False
+    strat.tx_builder.web3 = strat.feed.web3s["arbitrum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["arbitrum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+    result = strat.run_once()
+    assert result and result["action"].startswith("bridge_race")
+
+
+def test_snapshot_restore(tmp_path):
+    strat = setup_strat()
+    strat.last_prices = {"arbitrum": 1.0}
+    strat.pending_bridges = {"zksync": 2}
+    snap = tmp_path / "snap.json"
+    strat.snapshot(snap)
+    strat.last_prices = {}
+    strat.pending_bridges = {}
+    strat.restore(snap)
+    data = json.loads(snap.read_text())
+    assert strat.last_prices["arbitrum"] == 1.0
+    assert strat.pending_bridges["zksync"] == 2
+    assert data["last_prices"]["arbitrum"] == 1.0
+
+
+def test_kill_switch(monkeypatch):
+    strat = setup_strat()
+    strat.feed = DummyFeed({"arbitrum": 100, "zksync": 102})
+    strat.intent_feed = DummyIntentFeed({"zksync": []})
+    strat.tx_builder.web3 = strat.feed.web3s["arbitrum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["arbitrum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+    tmp = tempfile.mkdtemp()
+    monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
+    monkeypatch.setattr(
+        "strategies.l3_app_rollup_mev.strategy.kill_switch_triggered", lambda: True
+    )
+    result = strat.run_once()
+    assert result is None
+
+
+def test_mutate_hook():
+    strat = setup_strat(threshold=0.01)
+    strat.mutate({"threshold": 0.02, "edges_enabled": {"bridge_race": False}})
+    assert strat.threshold == 0.02
+    assert strat.edges_enabled["bridge_race"] is False


### PR DESCRIPTION
## Summary
- implement `l3_app_rollup_mev` strategy for L3/app rollup MEV edges
- add `IntentFeed` oracle
- provide fork simulation harness
- include adversarial and DRP tests
- document runbook in README and AGENTS

## Testing
- `ruff check .`
- `flake8`
- `mypy .`
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/l3_app_rollup_mev` *(fails: web3 required for fork simulation)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/l3_app_rollup_mev.json`