### PR TITLE
Add optional DRP archive encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ the values used in tests and the simulation harness:
 | `CROSS_ARB_TX_PRE` | `state/tx_pre.json` | Tx builder snapshot before |
 | `CROSS_ROLLUP_LOG` | `logs/cross_rollup_superbot.json` | cross_rollup_superbot log |
 | `ERROR_LOG_FILE` | `logs/errors.log` | Shared error log |
+| `DRP_ENC_KEY` | `<none>` | Optional key to encrypt DRP archives |
 | `FORK_BLOCK` | `19741234` | Fork block for sim harness |
 | `FOUNDER_APPROVED` | `0` | 1 allows promote to production |
 | `INTENT_FEED_URL` | `http://localhost:9000` | L3 intent feed |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -50,6 +50,9 @@ Create a Disaster Recovery Package (DRP) after successful tests:
 bash scripts/export_state.sh
 ```
 
+Set `DRP_ENC_KEY` to encrypt the archive with `openssl` or `gpg`. The same
+variable must be provided to `scripts/rollback.sh` for decryption.
+
 Restore from an archive if needed:
 
 ```bash

--- a/scripts/export_state.sh
+++ b/scripts/export_state.sh
@@ -60,6 +60,26 @@ done
 if [[ ${#ITEMS[@]} -gt 0 ]]; then
     tar -czf "$EXPORT_DIR/$ARCHIVE" "${ITEMS[@]}"
     echo "Export created at $EXPORT_DIR/$ARCHIVE"
+
+    if [[ -n "${DRP_ENC_KEY:-}" ]]; then
+        if command -v openssl >/dev/null 2>&1; then
+            echo -n "$DRP_ENC_KEY" | \
+                openssl enc -aes-256-cbc -pbkdf2 -salt -pass stdin \
+                -in "$EXPORT_DIR/$ARCHIVE" -out "$EXPORT_DIR/$ARCHIVE.enc"
+            rm "$EXPORT_DIR/$ARCHIVE"
+            ARCHIVE="$ARCHIVE.enc"
+            echo "Archive encrypted with openssl"
+        elif command -v gpg >/dev/null 2>&1; then
+            echo "$DRP_ENC_KEY" | \
+                gpg --batch --yes --passphrase-fd 0 -c \
+                -o "$EXPORT_DIR/$ARCHIVE.gpg" "$EXPORT_DIR/$ARCHIVE"
+            rm "$EXPORT_DIR/$ARCHIVE"
+            ARCHIVE="$ARCHIVE.gpg"
+            echo "Archive encrypted with gpg"
+        else
+            echo "Encryption requested but openssl or gpg not found" >&2
+        fi
+    fi
 else
     echo "Warning: nothing to export" >&2
 fi

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -36,7 +36,7 @@ log_event() {
 }
 
 if [[ -z "$ARCHIVE" ]]; then
-    ARCHIVE=$(ls -1t "$EXPORT_DIR"/drp_export_*.tar.gz 2>/dev/null | head -n1 || true)
+    ARCHIVE=$(ls -1t "$EXPORT_DIR"/drp_export_*.tar.* 2>/dev/null | head -n1 || true)
 fi
 
 if [[ -z "$ARCHIVE" || ! -f "$ARCHIVE" ]]; then
@@ -45,6 +45,47 @@ if [[ -z "$ARCHIVE" || ! -f "$ARCHIVE" ]]; then
     log_event "failed" "$ARCHIVE"
     echo "No DRP archive found" >&2
     exit 1
+fi
+
+# decrypt if needed
+if [[ "$ARCHIVE" == *.enc ]]; then
+    if [[ -z "${DRP_ENC_KEY:-}" ]]; then
+        echo "DRP_ENC_KEY required for decryption" >&2
+        exit 1
+    fi
+    if command -v openssl >/dev/null 2>&1; then
+        echo -n "$DRP_ENC_KEY" | \
+            openssl enc -d -aes-256-cbc -pbkdf2 -pass stdin \
+            -in "$ARCHIVE" -out "${ARCHIVE%.enc}"
+        ARCHIVE="${ARCHIVE%.enc}"
+    elif command -v gpg >/dev/null 2>&1; then
+        echo "$DRP_ENC_KEY" | \
+            gpg --batch --yes --passphrase-fd 0 -o "${ARCHIVE%.enc}" -d "$ARCHIVE"
+        ARCHIVE="${ARCHIVE%.enc}"
+    else
+        echo "No openssl or gpg available for decryption" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$ARCHIVE" == *.gpg ]]; then
+    if [[ -z "${DRP_ENC_KEY:-}" ]]; then
+        echo "DRP_ENC_KEY required for decryption" >&2
+        exit 1
+    fi
+    if command -v gpg >/dev/null 2>&1; then
+        echo "$DRP_ENC_KEY" | \
+            gpg --batch --yes --passphrase-fd 0 -o "${ARCHIVE%.gpg}" -d "$ARCHIVE"
+        ARCHIVE="${ARCHIVE%.gpg}"
+    elif command -v openssl >/dev/null 2>&1; then
+        echo -n "$DRP_ENC_KEY" | \
+            openssl enc -d -aes-256-cbc -pbkdf2 -pass stdin \
+            -in "$ARCHIVE" -out "${ARCHIVE%.gpg}"
+        ARCHIVE="${ARCHIVE%.gpg}"
+    else
+        echo "No openssl or gpg available for decryption" >&2
+        exit 1
+    fi
 fi
 
 # Extract archive relative to repo root

--- a/tests/test_export_state_sh.py
+++ b/tests/test_export_state_sh.py
@@ -65,3 +65,42 @@ def test_dry_run(tmp_path):
     assert not export_dir.exists()
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     assert entries[-1]["mode"] == "dry-run"
+
+
+def test_export_encrypted(tmp_path):
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "log.txt").write_text("log")
+    export_dir = tmp_path / "export"
+    log_file = tmp_path / "log.json"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    openssl_path = bin_dir / "openssl"
+    openssl_path.write_text(
+        "#!/bin/bash\n"
+        "while [[ $# -gt 0 ]]; do\n"
+        " case \"$1\" in\n"
+        "  -in) IN=$2; shift 2;;\n"
+        "  -out) OUT=$2; shift 2;;\n"
+        "  *) shift;;\n"
+        " esac\n"
+        "done\n"
+        "cp \"$IN\" \"$OUT\"\n"
+    )
+    openssl_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "EXPORT_DIR": str(export_dir),
+        "EXPORT_LOG_FILE": str(log_file),
+        "PWD": str(tmp_path),
+        "DRP_ENC_KEY": "secret",
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+    })
+    os.chdir(tmp_path)
+
+    run_script([], env)
+    archives = list(export_dir.glob("drp_export_*.tar.gz.enc"))
+    assert len(archives) == 1
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert entries[-1]["mode"] == "export"

--- a/tests/test_rollback_sh.py
+++ b/tests/test_rollback_sh.py
@@ -64,3 +64,48 @@ def test_missing_archive(tmp_path):
     entries = [json.loads(line) for line in (tmp_path / "rb.log").read_text().splitlines()]
     assert entries[-1]["event"] == "failed"
     assert (tmp_path / "err.log").exists()
+
+
+def test_restore_encrypted(tmp_path):
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "log.txt").write_text("log")
+    archive = export_dir / "drp_export_test.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(logs, arcname="logs")
+    encrypted = archive.with_suffix(archive.suffix + '.enc')
+    shutil.copyfile(archive, encrypted)
+    shutil.rmtree(logs)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    openssl_path = bin_dir / "openssl"
+    openssl_path.write_text(
+        "#!/bin/bash\n"
+        "while [[ $# -gt 0 ]]; do\n"
+        " case \"$1\" in\n"
+        "  -in) IN=$2; shift 2;;\n"
+        "  -out) OUT=$2; shift 2;;\n"
+        "  *) shift;;\n"
+        " esac\n"
+        "done\n"
+        "cp \"$IN\" \"$OUT\"\n"
+    )
+    openssl_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "ERROR_LOG_FILE": str(tmp_path / "err.log"),
+        "ROLLBACK_LOG_FILE": str(tmp_path / "rb.log"),
+        "PWD": str(tmp_path),
+        "DRP_ENC_KEY": "secret",
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+    })
+    os.chdir(tmp_path)
+
+    run_script([f"--archive={encrypted}"], env)
+    assert (tmp_path / "logs" / "log.txt").exists()
+    entries = [json.loads(line) for line in (tmp_path / "rb.log").read_text().splitlines()]
+    assert entries[-1]["event"] == "restore"


### PR DESCRIPTION
## Summary
- support encryption in `export_state.sh` via `openssl` or `gpg`
- decrypt archives in `rollback.sh`
- document `DRP_ENC_KEY` variable
- update onboarding docs
- mock encryption/decryption in tests

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: web3 required)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json`