### PR TITLE
Add token auth to metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Start the metrics endpoint with:
 python -m core.metrics --port $METRICS_PORT
 ```
 and point Prometheus to `http://localhost:$METRICS_PORT/metrics` for monitoring.
+If `METRICS_TOKEN` is set, include `Authorization: Bearer $METRICS_TOKEN` in
+requests.
 
 ### Environment & Configuration
 
@@ -127,6 +129,7 @@ RPC_ARBITRUM_URL=<https://arbitrum.rpc>
 RPC_OPTIMISM_URL=<https://optimism.rpc>
 KILL_SWITCH_PATH=/tmp/mev_kill            # File trigger for halt
 METRICS_PORT=9102                         # Prometheus server port
+METRICS_TOKEN=<optional-token>            # Require auth header if set
 ```
 
 Additional strategy values:

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -31,6 +31,7 @@ _METRICS: Dict[str, List[float] | float | int] = {
     "alert_count": 0,
 }
 _LOCK = threading.Lock()
+_METRICS_TOKEN = os.getenv("METRICS_TOKEN")
 
 
 # ----------------------------------------------------------------------
@@ -62,6 +63,12 @@ def record_alert() -> None:
 class _Handler(BaseHTTPRequestHandler):
     """Serve metrics data for Prometheus scraping."""
     def do_GET(self) -> None:  # pragma: no cover - trivial
+        if _METRICS_TOKEN:
+            auth = self.headers.get("Authorization")
+            if auth != f"Bearer {_METRICS_TOKEN}":
+                self.send_response(401)
+                self.end_headers()
+                return
         if self.path != "/metrics":
             self.send_response(404)
             self.end_headers()

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -64,6 +64,8 @@ server for Prometheus scraping with:
 ```bash
 python -m core.metrics --port $METRICS_PORT
 ```
+If you set `METRICS_TOKEN`, include the header
+`Authorization: Bearer $METRICS_TOKEN` when scraping.
 
 ---
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,6 +7,8 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core import metrics
+import importlib
+import os
 
 opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
@@ -28,3 +30,38 @@ def test_metrics_server(tmp_path):
     assert "opportunities_total 1" in data
     assert "fails_total 1" in data
     assert "alert_count 1" in data
+
+
+def _start_server_with_token(monkeypatch, token):
+    monkeypatch.setenv("METRICS_TOKEN", token)
+    importlib.reload(metrics)
+    srv = metrics.MetricsServer(port=0)
+    srv.start()
+    return srv
+
+
+def test_metrics_authorized(monkeypatch):
+    token = "secret"
+    srv = _start_server_with_token(monkeypatch, token)
+    host, port = srv.server.server_address
+    req = urllib.request.Request(
+        f"http://{host}:{port}/metrics", headers={"Authorization": f"Bearer {token}"}
+    )
+    data = opener.open(req).read().decode()
+    srv.stop()
+    assert "opportunities_total" in data
+
+
+def test_metrics_unauthorized(monkeypatch):
+    token = "secret"
+    srv = _start_server_with_token(monkeypatch, token)
+    host, port = srv.server.server_address
+    req = urllib.request.Request(f"http://{host}:{port}/metrics")
+    try:
+        opener.open(req)
+    except urllib.error.HTTPError as exc:
+        assert exc.code == 401
+    else:
+        raise AssertionError("expected 401")
+    finally:
+        srv.stop()


### PR DESCRIPTION
## Summary
- secure metrics endpoint with optional token auth
- document the new `METRICS_TOKEN` option
- show how to authenticate when scraping metrics
- test authorized and unauthorized access

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/test.json` *(fails: ModuleNotFoundError)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: web3 required)*