### PR TITLE
Integrate CapitalLock gating into all strategies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ This file is the single source of truth for mutation, validation, and integratio
   `scripts/export_state.sh`.
 - OpsAgent monitors health, pauses on failure, and sends alerts via webhooks.
 - CapitalLock enforces drawdown/loss thresholds; unlocks require founder approval.
+ - Strategies must call `capital_lock.trade_allowed()` before every trade.
+   If False, abort and log "capital lock: trade not allowed" to the strategy log
+   and `logs/errors.log` with `risk_level` "high".
 
 ---
 
@@ -90,6 +93,12 @@ Every PR or batch/module must pass:
 - Use `scripts/batch_ops.py` to promote, pause or rollback strategies.
 - CapitalLock state is shared via `agents.agent_registry` and unpaused only when
   founder sets `FOUNDER_APPROVED=1` and calls `unlock`.
+ - Example strategy integration:
+   ```python
+   from agents.capital_lock import CapitalLock
+   lock = CapitalLock(max_drawdown_pct=5, max_loss_usd=100, balance_usd=1000)
+   strat = Strategy(..., capital_lock=lock)
+   ```
 
 ### rwa_settlement Runbook
 - Fork simulation: `bash scripts/simulate_fork.sh --target=strategies/rwa_settlement`

--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ any fail. Alerts are sent via `OPS_ALERT_WEBHOOK` and counted by the metrics
 server. `agents/capital_lock.py` enforces drawdown and loss limits; founder must
 approve unlock actions by setting `FOUNDER_APPROVED=1`.
 
+Each strategy receives a `CapitalLock` instance from the orchestrator. Before
+dispatching any transaction it calls `capital_lock.trade_allowed()`. When the
+lock is engaged the strategy aborts, logging a structured error entry with the
+message "capital lock: trade not allowed" to both its strategy log and
+`logs/errors.log`.
+
 ## Batch Operations
 
 `scripts/batch_ops.py` manages groups of strategies. It supports three actions:

--- a/tests/test_capital_lock_integration.py
+++ b/tests/test_capital_lock_integration.py
@@ -1,0 +1,101 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
+from agents.capital_lock import CapitalLock
+from core.oracles.uniswap_feed import PriceData
+
+
+class DummyPool:
+    def __init__(self, price):
+        self._price = price
+
+    class functions:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def slot0(self):
+            return lambda: (self.outer._price, 0, 0, 0, 0, 0, False)
+
+        def token0(self):
+            return lambda: "0x0"
+
+        def token1(self):
+            return lambda: "0x1"
+
+    def __getattr__(self, item):
+        return getattr(self.functions(self), item)
+
+
+class DummyEth:
+    def __init__(self, price):
+        self.contract_obj = DummyPool(price)
+        self.block_number = 1
+
+    def contract(self, address, abi):
+        return self.contract_obj
+
+    def get_block(self, block):
+        return type("B", (), {"number": 1, "timestamp": 1})
+
+    def get_transaction_count(self, address):
+        return 0
+
+    def estimate_gas(self, tx):
+        return 21000
+
+    class account:
+        @staticmethod
+        def decode_transaction(tx):
+            return {}
+
+
+class DummyWeb3:
+    def __init__(self, price):
+        self.eth = DummyEth(price)
+
+
+class DummyFeed:
+    def __init__(self, prices):
+        self.prices = prices
+        self.web3s = {d: DummyWeb3(p) for d, p in prices.items()}
+
+    def fetch_price(self, pool, domain):
+        price = self.prices[domain]
+        return PriceData(price, pool, 1, 1, 0)
+
+
+def test_capital_lock_blocks_trade(tmp_path):
+    pools = {
+        "eth": PoolConfig("0xpool", "ethereum"),
+        "arb": PoolConfig("0xpool", "arbitrum"),
+    }
+    bridges = {("ethereum", "arbitrum"): BridgeConfig(0.0001)}
+    lock = CapitalLock(max_drawdown_pct=5, max_loss_usd=50, balance_usd=1000)
+    lock.record_trade(-60)
+    strat = CrossRollupSuperbot(pools, bridges, threshold=0.01, capital_lock=lock)
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+
+    log_file = tmp_path / "log.json"
+    err_file = tmp_path / "err.log"
+    os.environ["CROSS_ROLLUP_LOG"] = str(log_file)
+    os.environ["ERROR_LOG_FILE"] = str(err_file)
+    import strategies.cross_rollup_superbot.strategy as mod
+    mod.LOG.path = Path(os.environ["CROSS_ROLLUP_LOG"])
+
+    result = strat.run_once()
+    assert result is None
+
+    slog = json.loads(log_file.read_text().splitlines()[-1])
+    elog = json.loads(err_file.read_text().splitlines()[-1])
+    assert slog["error"] == "capital lock: trade not allowed"
+    assert slog["risk_level"] == "high"
+    assert elog["error"] == "capital lock: trade not allowed"
+    assert elog["risk_level"] == "high"

--- a/tests/test_cross_rollup_superbot.py
+++ b/tests/test_cross_rollup_superbot.py
@@ -8,6 +8,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
+from agents.capital_lock import CapitalLock
 from core.oracles.uniswap_feed import PriceData
 
 
@@ -78,7 +79,7 @@ def setup_strat(threshold=0.01):
         "arb": PoolConfig("0xpool", "arbitrum"),
     }
     bridges = {("ethereum", "arbitrum"): BridgeConfig(0.0001)}
-    strat = CrossRollupSuperbot(pools, bridges, threshold=threshold)
+    strat = CrossRollupSuperbot(pools, bridges, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 
 

--- a/tests/test_export_state_sh.py
+++ b/tests/test_export_state_sh.py
@@ -97,7 +97,6 @@ def test_export_encrypted(tmp_path):
         "PWD": str(tmp_path),
         "DRP_ENC_KEY": "secret",
         "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
-      ]
     })
     os.chdir(tmp_path)
 

--- a/tests/test_l3_app_rollup_mev.py
+++ b/tests/test_l3_app_rollup_mev.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.l3_app_rollup_mev import L3AppRollupMEV, PoolConfig, BridgeConfig
+from agents.capital_lock import CapitalLock
 from core.oracles.uniswap_feed import PriceData
 from core.oracles.intent_feed import IntentData
 
@@ -89,7 +90,7 @@ def setup_strat(threshold=0.01):
         "zksync": PoolConfig("0xpool", "zksync"),
     }
     bridges = {("zksync", "arbitrum"): BridgeConfig(0.0001, latency_sec=10)}
-    strat = L3AppRollupMEV(pools, bridges, threshold=threshold)
+    strat = L3AppRollupMEV(pools, bridges, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 
 

--- a/tests/test_l3_sequencer_mev.py
+++ b/tests/test_l3_sequencer_mev.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.l3_sequencer_mev import L3SequencerMEV, PoolConfig
+from agents.capital_lock import CapitalLock
 from core.oracles.uniswap_feed import PriceData
 
 
@@ -73,7 +74,7 @@ class DummyFeed:
 
 def setup_strat(threshold=0.001):
     pools = {"l3": PoolConfig("0xpool", "ethereum")}
-    strat = L3SequencerMEV(pools, threshold=threshold)
+    strat = L3SequencerMEV(pools, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 
 

--- a/tests/test_nft_liquidation.py
+++ b/tests/test_nft_liquidation.py
@@ -7,6 +7,7 @@ import types
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.nft_liquidation import NFTLiquidationMEV, AuctionConfig
+from agents.capital_lock import CapitalLock
 from core.oracles.nft_liquidation_feed import AuctionData
 
 
@@ -21,7 +22,7 @@ class DummyFeed:
 
 def setup_strat(discount=0.05):
     auctions = {"proto": AuctionConfig("proto", "ethereum")}
-    strat = NFTLiquidationMEV(auctions, discount=discount)
+    strat = NFTLiquidationMEV(auctions, discount=discount, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 
 

--- a/tests/test_rwa_settlement.py
+++ b/tests/test_rwa_settlement.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.rwa_settlement import RWASettlementMEV, VenueConfig
+from agents.capital_lock import CapitalLock
 from core.oracles.rwa_feed import RWAData
 
 
@@ -24,7 +25,7 @@ def setup_strat(threshold=0.01):
         "dex": VenueConfig("dex", "asset"),
         "cex": VenueConfig("cex", "asset"),
     }
-    strat = RWASettlementMEV(venues, threshold=threshold)
+    strat = RWASettlementMEV(venues, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 
 


### PR DESCRIPTION
## Summary
- inject CapitalLock into strategies for runtime risk gating
- block trades when capital lock is active and log structured errors
- record realized PnL for each trade
- document gating flow in AGENTS.md and README
- add regression test for capital lock blocking and update existing tests

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: Connection refused)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*