### PR TITLE
Improve orchestrator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ the values used in tests and the simulation harness:
 | `SUPERBOT_TX_POST` | `state/superbot_tx_post.json` | Tx builder post snapshot |
 | `SUPERBOT_TX_PRE` | `state/superbot_tx_pre.json` | Tx builder pre snapshot |
 | `TX_LOG_FILE` | `logs/tx_log.json` | Transaction builder log |
+| `ORCH_CONFIG` | `config.yaml` | Orchestrator config file |
+| `ORCH_LOGS_DIR` | `logs` | Directory for orchestrator logs |
+| `ORCH_MODE` | `dry-run` | Default run mode |
+| `WALLET_OPS_LOG` | `logs/wallet_ops.log` | Wallet operations audit log |
 
 ### cross_domain_arb Runbook
 
@@ -420,3 +424,62 @@ Example usage:
 ```bash
 python scripts/batch_ops.py promote cross_rollup_superbot --source-dir staging --dest-dir active
 ```
+
+## Orchestrator CLI
+
+`ai/mutator/main.py` orchestrates dry runs and live trading. Key options:
+
+```
+--logs-dir <path>   # strategy log directory
+--config <file>     # config path
+--dry-run           # run validations only
+--mode live|dry-run # override config mode
+```
+
+Dry-run example:
+
+```bash
+python ai/mutator/main.py --logs-dir logs --dry-run
+```
+
+After verifying results, remove `--dry-run` and set `mode: live` in
+`config.yaml`. A DRP archive is created automatically.
+
+## Wallet Ops CLI
+
+Use `scripts/wallet_ops.py` to safely fund or drain wallets.
+
+```bash
+python scripts/wallet_ops.py deposit 1.0   # fund 1 ETH
+python scripts/wallet_ops.py withdraw 0.5  # withdraw 0.5 ETH
+```
+
+Actions append to `logs/wallet_ops.log` for auditing.
+
+## Live Trade Checklist
+
+1. `poetry install` and `docker compose up -d`
+2. Copy `.env.example` to `.env` and fill RPC keys
+3. Copy `config.example.yaml` to `config.yaml`
+4. Run `pytest -v` and `foundry test`
+5. `bash scripts/simulate_fork.sh --target=strategies/<module>`
+6. `python ai/mutator/main.py --dry-run`
+7. Review `logs/errors.log` and DRP archive
+8. Set `FOUNDER_APPROVED=1` and run `python ai/mutator/main.py --mode live`
+9. Check metrics at `http://localhost:$METRICS_PORT/metrics`
+10. Drain funds with `wallet_ops.py` if needed
+
+## Troubleshooting / FAQ
+
+- **RPC failures:** confirm endpoints in `config.yaml` and ensure nodes are live.
+- **Metrics missing:** run `python -m core.metrics --port $METRICS_PORT`.
+- **Promotion blocked:** check `FOUNDER_APPROVED=1` and read `logs/errors.log`.
+- **Rollback:** `bash scripts/rollback.sh --archive=<archive>`.
+
+## Green-light Checklist
+
+- Tests and fork simulations pass
+- DRP snapshot exported
+- Metrics endpoint live
+- Wallet balances checked via `wallet_ops.py`
+- `FOUNDER_APPROVED=1` set for live mode

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -70,6 +70,50 @@ python -m core.metrics --port $METRICS_PORT
 If you set `METRICS_TOKEN`, include the header
 `Authorization: Bearer $METRICS_TOKEN` when scraping.
 
+## 6. Running the Orchestrator
+
+`ai/mutator/main.py` serves as the live orchestrator. Use `--help` for a full
+list of options. The most important flags are:
+
+```
+--logs-dir <path>      # where strategy logs are read from
+--config <file>        # path to config.yaml (defaults to ./config.yaml)
+--dry-run              # run checks without promoting changes
+--mode live|dry-run    # explicit trade mode override
+```
+
+Example dry-run:
+
+```bash
+python ai/mutator/main.py --logs-dir logs --dry-run
+```
+
+If the run completes with no errors you can promote to live trading by removing
+`--dry-run` and ensuring `config.yaml` has `mode: live`.
+
+### DRP snapshots and restore
+
+The orchestrator exports a Disaster Recovery Package by calling
+`scripts/export_state.sh`. Restore from a snapshot with:
+
+```bash
+bash scripts/rollback.sh --archive=<exported-archive>
+```
+
+### Kill/Pause/Rollback flows
+
+* **Kill switch:** `bash scripts/kill_switch.sh` toggles trading halt.
+* **Pause strategy:** `python scripts/batch_ops.py pause <strategy>`.
+* **Rollback:** `python scripts/batch_ops.py rollback <strategy>` or use the DRP
+  archive as shown above.
+
+### Troubleshooting
+
+* Check `logs/errors.log` for stack traces.
+* Ensure RPC endpoints in `config.yaml` are reachable.
+* Verify the metrics server is running on `$METRICS_PORT`.
+
+
 ---
 
 Refer to [AGENTS.md](../AGENTS.md) and [PROJECT_BIBLE.md](../PROJECT_BIBLE.md) for

--- a/tests/test_export_state_sh.py
+++ b/tests/test_export_state_sh.py
@@ -93,11 +93,9 @@ def test_export_encrypted(tmp_path):
     env.update({
         "EXPORT_DIR": str(export_dir),
         "EXPORT_LOG_FILE": str(log_file),
-
         "PWD": str(tmp_path),
         "DRP_ENC_KEY": "secret",
         "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
-      ]
     })
     os.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- document orchestrator CLI options and wallet ops commands
- add running orchestrator instructions to onboarding
- fix syntax error in export state tests

## Testing
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: connection refused)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*