### PR TITLE
Improve cross domain arb strategy

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,0 +1,16 @@
+"""Adapters package for external APIs."""
+
+from .bridge_adapter import BridgeAdapter
+from .cex_adapter import CEXAdapter
+from .dex_adapter import DEXAdapter
+from .flashloan_adapter import FlashloanAdapter
+from .pool_scanner import PoolScanner, PoolInfo
+
+__all__ = [
+    "BridgeAdapter",
+    "CEXAdapter",
+    "DEXAdapter",
+    "FlashloanAdapter",
+    "PoolScanner",
+    "PoolInfo",
+]

--- a/adapters/flashloan_adapter.py
+++ b/adapters/flashloan_adapter.py
@@ -1,0 +1,32 @@
+"""Flashloan execution adapter."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from core.logger import StructuredLogger
+
+LOG = StructuredLogger("flashloan_adapter")
+
+
+class FlashloanAdapter:
+    """Execute flashloans to induce price moves for latency farming."""
+
+    def __init__(self, api_url: str) -> None:
+        self.api_url = api_url.rstrip("/")
+
+    def trigger(self, token: str, amount: float) -> Dict[str, Any]:
+        """Perform the flashloan using an external service."""
+        try:
+            import requests  # type: ignore
+
+            resp = requests.post(
+                f"{self.api_url}/flashloan",
+                json={"token": token, "amount": amount},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - network errors
+            LOG.log("flashloan_fail", risk_level="high", error=str(exc))
+            raise

--- a/adapters/pool_scanner.py
+++ b/adapters/pool_scanner.py
@@ -1,0 +1,35 @@
+"""Discover new DEX pools across domains."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from core.logger import StructuredLogger
+
+LOG = StructuredLogger("pool_scanner")
+
+
+@dataclass
+class PoolInfo:
+    pool: str
+    domain: str
+
+
+class PoolScanner:
+    """Scan subgraph or RPC endpoints for newly deployed pools."""
+
+    def __init__(self, api_url: str) -> None:
+        self.api_url = api_url.rstrip("/")
+
+    def scan(self) -> List[PoolInfo]:
+        try:
+            import requests  # type: ignore
+
+            resp = requests.get(f"{self.api_url}/pools", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            return [PoolInfo(**d) for d in data]
+        except Exception as exc:  # pragma: no cover - network errors
+            LOG.log("scan_fail", risk_level="high", error=str(exc))
+            return []

--- a/ai/intent_classifier.py
+++ b/ai/intent_classifier.py
@@ -1,0 +1,27 @@
+"""Simple intent classifier using heuristics or ML stubs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from core.logger import StructuredLogger
+
+LOG = StructuredLogger("intent_classifier")
+
+
+def classify_intent(intent: Dict[str, Any]) -> str:
+    """Classify intent hint into target domain or venue.
+
+    This is a stub for a more advanced ML model. Currently returns
+    ``intent.get('domain', 'unknown')`` and logs the classification event.
+    """
+    domain = intent.get("domain", "unknown")
+    LOG.log(
+        "classify",
+        strategy_id="cross_domain_arb",
+        mutation_id="dev",
+        risk_level="low",
+        intent_id=intent.get("intent_id", ""),
+        predicted=domain,
+    )
+    return domain

--- a/core/mempool_monitor.py
+++ b/core/mempool_monitor.py
@@ -1,0 +1,42 @@
+"""Lightweight Ethereum mempool monitor for bridge transactions."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterator
+
+from core.logger import StructuredLogger
+
+try:
+    from web3 import Web3  # type: ignore
+except Exception:  # pragma: no cover - optional
+    Web3 = None  # type: ignore
+
+LOG = StructuredLogger("mempool_monitor")
+
+
+class MempoolMonitor:
+    """Monitor pending transactions for bridge activity."""
+
+    def __init__(self, web3: Web3 | None) -> None:
+        self.web3 = web3
+
+    def listen_bridge_txs(self, limit: int = 10) -> Iterator[Dict[str, object]]:
+        """Yield pending bridge transactions up to ``limit``."""
+        if self.web3 is None:
+            return iter([])
+        try:
+            filt = self.web3.eth.filter("pending")
+            count = 0
+            while count < limit:
+                hashes = filt.get_new_entries()
+                for h in hashes:
+                    tx = self.web3.eth.get_transaction(h)
+                    if tx and tx.get("to"):
+                        yield dict(tx)
+                        count += 1
+                        if count >= limit:
+                            break
+        except Exception as exc:  # pragma: no cover - network errors
+            LOG.log("mempool_fail", risk_level="high", error=str(exc))
+            return iter([])
+        return iter([])

--- a/core/node_selector.py
+++ b/core/node_selector.py
@@ -1,0 +1,51 @@
+"""RPC/relay node performance tracker and selector."""
+
+from __future__ import annotations
+
+from statistics import mean
+from typing import Dict, List
+
+from core.logger import StructuredLogger
+
+LOG = StructuredLogger("node_selector")
+
+
+class NodeSelector:
+    """Select the best-performing RPC or relay node."""
+
+    def __init__(self, nodes: Dict[str, str]) -> None:
+        self.nodes = nodes
+        self.stats: Dict[str, Dict[str, List[float] | int]] = {
+            n: {"latencies": [], "success": 0, "fail": 0} for n in nodes
+        }
+
+    def record(self, node: str, success: bool, latency: float) -> None:
+        if node not in self.stats:
+            return
+        self.stats[node]["latencies"].append(latency)  # type: ignore[arg-type]
+        if success:
+            self.stats[node]["success"] = int(self.stats[node]["success"]) + 1
+        else:
+            self.stats[node]["fail"] = int(self.stats[node]["fail"]) + 1
+        LOG.log(
+            "node_perf",
+            node=node,
+            success=success,
+            latency=latency,
+            strategy_id="cross_domain_arb",
+            mutation_id="dev",
+            risk_level="low",
+        )
+
+    def best(self) -> str:
+        best_node = None
+        best_score = float("inf")
+        for node, st in self.stats.items():
+            latencies = st["latencies"]
+            if not latencies:
+                continue
+            score = mean(latencies) * (1 + st["fail"])  # penalize failures
+            if score < best_score:
+                best_score = score
+                best_node = node
+        return best_node or list(self.nodes)[0]

--- a/infra/sim_harness/fork_sim_cross_arb.py
+++ b/infra/sim_harness/fork_sim_cross_arb.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from strategies.cross_domain_arb.strategy import CrossDomainArb, PoolConfig
+from strategies.cross_domain_arb.strategy import CrossDomainArb, PoolConfig, BridgeConfig
 
 try:  # pragma: no cover
     from web3 import Web3
@@ -26,13 +26,15 @@ POOLS = {
     "opt": PoolConfig(os.getenv("POOL_OPTIMISM", "0x85149247691df622eaf1a8bd0c4bd90d38a83a1f"), "optimism"),
 }
 
+BRIDGE_COSTS = {}
+
 
 def main() -> None:  # pragma: no cover
     w3 = Web3(Web3.HTTPProvider(RPC_ETH))
     w3.middleware_onion.add(geth_poa_middleware)
     if w3.eth.block_number < FORK_BLOCK:
         raise SystemExit("RPC must be forked at or after block %s" % FORK_BLOCK)
-    strategy = CrossDomainArb(POOLS)
+    strategy = CrossDomainArb(POOLS, BRIDGE_COSTS)
     found = False
     for _ in range(10):
         result = strategy.run_once()

--- a/strategies/cross_domain_arb/__init__.py
+++ b/strategies/cross_domain_arb/__init__.py
@@ -1,5 +1,5 @@
 """Cross domain arbitrage strategy package."""
 
-from .strategy import CrossDomainArb, PoolConfig
+from .strategy import CrossDomainArb, PoolConfig, BridgeConfig
 
-__all__ = ["CrossDomainArb", "PoolConfig"]
+__all__ = ["CrossDomainArb", "PoolConfig", "BridgeConfig"]

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -23,11 +23,8 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from statistics import mean
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple, TypedDict, List
 
 try:  # webhook optional
     import requests
@@ -36,10 +33,17 @@ except Exception:  # pragma: no cover - allow missing dependency
 
 from core.tx_engine.builder import TransactionBuilder, HexBytes
 from core.tx_engine.nonce_manager import NonceManager
-from core.logger import log_error
+from core.logger import StructuredLogger, log_error
+from core import metrics
 from agents.capital_lock import CapitalLock
 
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
+from core.oracles.intent_feed import IntentFeed, IntentData
+from core.mempool_monitor import MempoolMonitor
+from core.node_selector import NodeSelector
+from ai.intent_classifier import classify_intent
+from adapters.flashloan_adapter import FlashloanAdapter
+from adapters.pool_scanner import PoolScanner, PoolInfo
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 
 LOG_FILE = Path(os.getenv("CROSS_ARB_LOG", "logs/cross_domain_arb.json"))
@@ -48,45 +52,25 @@ logging.basicConfig(level=logging.INFO)
 
 STRATEGY_ID = "cross_domain_arb"
 
-# Metrics storage
-METRICS = {
-    "opportunities": 0,
-    "fails": 0,
-    "spreads": [],
-}
+LOG = StructuredLogger("cross_domain_arb", log_file=str(LOG_FILE))
 
 
-class _MetricsHandler(BaseHTTPRequestHandler):
-    """HTTP handler serving in-memory metrics."""
-    def do_GET(self) -> None:  # pragma: no cover - simple server
-        if self.path != "/metrics":
-            self.send_response(404)
-            self.end_headers()
-            return
-        avg_spread = mean(METRICS["spreads"]) if METRICS["spreads"] else 0.0
-        body = (
-            f"opportunities_total {METRICS['opportunities']}\n"
-            f"fails_total {METRICS['fails']}\n"
-            f"spread_average {avg_spread}\n"
-        ).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "text/plain")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+class BridgeConfig(TypedDict, total=False):
+    """Bridge cost assumptions between domains."""
+
+    cost: float
+    latency_sec: int
 
 
-def start_metrics_server(port: int = 8000) -> HTTPServer:
-    """Start background metrics server for Prometheus scraping."""
-    server = HTTPServer(("0.0.0.0", port), _MetricsHandler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return server
+def start_metrics_server(port: int = 8000) -> metrics.MetricsServer:
+    """Backward compatible helper to start metrics server."""
+    srv = metrics.MetricsServer(port=port)
+    srv.start()
+    return srv
 
 
-def _log(entry: Dict[str, object]) -> None:
-    with LOG_FILE.open("a") as fh:
-        fh.write(json.dumps(entry) + "\n")
+def _log(event: str, **entry: object) -> None:
+    LOG.log(event, strategy_id=STRATEGY_ID, mutation_id=os.getenv("MUTATION_ID", "dev"), risk_level="low", **entry)
 
 
 def _send_alert(payload: Dict[str, object]) -> None:
@@ -96,6 +80,7 @@ def _send_alert(payload: Dict[str, object]) -> None:
         return
     try:  # pragma: no cover - network
         requests.post(url, json=payload, timeout=5)
+        metrics.record_alert()
     except Exception as exc:  # pragma: no cover - network
         logging.warning("webhook failed: %s", exc)
         log_error(STRATEGY_ID, f"webhook failed: {exc}", event="webhook_fail")
@@ -109,13 +94,23 @@ class PoolConfig:
 
 
 class CrossDomainArb:
-    """Detect price spreads across domains."""
+    """Detect price spreads across domains and execute cost-aware trades."""
 
     DEFAULT_THRESHOLD = 0.003
 
-    def __init__(self, pools: Dict[str, PoolConfig], threshold: float | None = None, *, capital_lock: CapitalLock | None = None) -> None:
+    def __init__(
+        self,
+        pools: Dict[str, PoolConfig],
+        bridge_costs: Dict[Tuple[str, str], BridgeConfig],
+        threshold: float | None = None,
+        *,
+        nodes: Optional[Dict[str, str]] = None,
+        edges_enabled: Optional[Dict[str, bool]] = None,
+        capital_lock: CapitalLock | None = None,
+    ) -> None:
         self.feed = UniswapV3Feed()
         self.pools = pools
+        self.bridge_costs = bridge_costs
         self.threshold = threshold if threshold is not None else self.DEFAULT_THRESHOLD
         self.last_prices: Dict[str, float] = {}
 
@@ -127,6 +122,141 @@ class CrossDomainArb:
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("ARB_EXECUTOR_ADDR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")
+
+        self.intent_feed = IntentFeed()
+        self.mempool_monitor = MempoolMonitor(w3)
+        self.node_selector = NodeSelector(nodes or {}) if nodes else None
+        self.flashloan = FlashloanAdapter(os.getenv("FLASHLOAN_API", "http://localhost:9001"))
+        self.pool_scanner = PoolScanner(os.getenv("POOL_SCANNER_API", "http://localhost:9002"))
+        self.edges_enabled = edges_enabled or {
+            "l1_sandwich": True,
+            "intent": True,
+            "flashloan": False,
+            "auto_discover": True,
+        }
+
+    # ------------------------------------------------------------------
+    def _estimate_gas_cost(self) -> float:
+        try:
+            gas_price = getattr(self.tx_builder.web3.eth, "gas_price", 0)
+            gas_estimate = self.tx_builder.web3.eth.estimate_gas({})
+            return float(gas_price * gas_estimate) / 1e18
+        except Exception:
+            return float(os.getenv("GAS_COST_OVERRIDE", "0"))
+
+    def _compute_profit(self, buy: str, sell: str, prices: Dict[str, float]) -> float:
+        price_buy = prices[buy]
+        price_sell = prices[sell]
+        spread = price_sell - price_buy
+        bridge_fee = self.bridge_costs.get((buy, sell), {}).get("cost", 0.0)
+        slippage_pct = float(os.getenv("SLIPPAGE_PCT", "0"))
+        slippage = price_buy * slippage_pct
+        gas_cost = self._estimate_gas_cost()
+        return spread - gas_cost - bridge_fee - slippage
+
+    # ------------------------------------------------------------------
+    def _auto_discover(self) -> None:
+        if not self.edges_enabled.get("auto_discover", True):
+            return
+        for info in self.pool_scanner.scan():
+            if info.pool not in self.pools:
+                self.pools[info.pool] = PoolConfig(info.pool, info.domain)
+                LOG.log(
+                    "new_pool",
+                    pool=info.pool,
+                    domain=info.domain,
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                )
+
+    # ------------------------------------------------------------------
+    def _check_l1_sandwich(self) -> bool:
+        if not self.edges_enabled.get("l1_sandwich", True):
+            return True
+        for tx in self.mempool_monitor.listen_bridge_txs(limit=1):
+            pre = os.getenv("CROSS_ARB_STATE_PRE", "state/cross_arb_pre.json")
+            post = os.getenv("CROSS_ARB_STATE_POST", "state/cross_arb_post.json")
+            tx_pre = os.getenv("CROSS_ARB_TX_PRE", "state/tx_pre.json")
+            tx_post = os.getenv("CROSS_ARB_TX_POST", "state/tx_post.json")
+            for p in (pre, post, tx_pre, tx_post):
+                Path(p).parent.mkdir(parents=True, exist_ok=True)
+            self.snapshot(pre)
+            self.tx_builder.snapshot(tx_pre)
+            try:
+                front = self.tx_builder.send_transaction(
+                    self.sample_tx,
+                    self.executor,
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                )
+                back = self.tx_builder.send_transaction(
+                    self.sample_tx,
+                    self.executor,
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                )
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"sandwich tx fail: {exc}", event="sandwich_fail")
+                metrics.record_fail()
+                return False
+            self.tx_builder.snapshot(tx_post)
+            self.snapshot(post)
+            LOG.log(
+                "sandwich",
+                tx_id=str(front),
+                related=str(back),
+                bridge_tx=str(tx.get("hash")),
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="low",
+            )
+            metrics.record_opportunity(0.0, 0.0, 0.0)
+            return True
+        return True
+    # ------------------------------------------------------------------
+    def _process_intents(self) -> None:
+        if not self.edges_enabled.get("intent", True):
+            return
+        for domain in self.pools:
+            try:
+                intents: List[IntentData] = self.intent_feed.fetch_intents(domain)
+            except Exception as exc:
+                log_error(STRATEGY_ID, f"intent fetch: {exc}", event="intent_fetch", domain=domain)
+                continue
+            for intent in intents:
+                dest = classify_intent(intent.__dict__)
+                LOG.log(
+                    "intent_route",
+                    intent_id=intent.intent_id,
+                    predicted=dest,
+                    domain=domain,
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                )
+
+    # ------------------------------------------------------------------
+    def _execute_flashloan(self, buy: str, sell: str) -> None:
+        if not self.edges_enabled.get("flashloan", False):
+            return
+        token = "ETH"
+        amount = float(os.getenv("FLASHLOAN_AMOUNT", "1"))
+        try:
+            res = self.flashloan.trigger(token, amount)
+            LOG.log(
+                "flashloan",
+                token=token,
+                amount=amount,
+                result=str(res),
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="low",
+            )
+        except Exception as exc:
+            log_error(STRATEGY_ID, f"flashloan: {exc}", event="flashloan_fail")
 
     # ------------------------------------------------------------------
     def snapshot(self, path: str) -> None:
@@ -140,26 +270,23 @@ class CrossDomainArb:
                 self.last_prices = json.load(fh)
 
     # ------------------------------------------------------------------
-    def _record(self, domain: str, data: PriceData, opportunity: bool, spread: float, action: str = "", tx_id: str = "") -> None:
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "domain": domain,
-            "price": data.price,
-            "opportunity": opportunity,
-            "spread": spread,
-            "action": action,
-            "tx_id": tx_id,
-            "strategy_id": STRATEGY_ID,
-            "risk_level": "low",
-            "mutation_id": os.getenv("MUTATION_ID", "dev"),
-            "block_number": data.block,
-            "block_age_sec": data.block_age,
-        }
-        _log(entry)
+    def _record(self, domain: str, data: PriceData, opportunity: bool, spread: float, action: str = "", tx_id: str = "", pnl: float = 0.0) -> None:
+        _log(
+            "price",
+            domain=domain,
+            price=data.price,
+            opportunity=opportunity,
+            spread=spread,
+            action=action,
+            tx_id=tx_id,
+            block=data.block,
+            block_age=data.block_age,
+            pnl=pnl,
+        )
 
     def _detect_opportunity(self, prices: Dict[str, float]) -> Optional[Dict[str, object]]:
         domains = list(prices.keys())
-        if not domains:
+        if len(domains) < 2:
             return None
         min_domain = min(domains, key=lambda d: prices[d])
         max_domain = max(domains, key=lambda d: prices[d])
@@ -186,7 +313,25 @@ class CrossDomainArb:
     def run_once(self) -> Optional[Dict[str, object]]:
         if kill_switch_triggered():
             record_kill_event(STRATEGY_ID)
+            LOG.log(
+                "killed",
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="high",
+            )
             return None
+
+        self._auto_discover()
+
+        if self.node_selector:
+            node = self.node_selector.best()
+            LOG.log(
+                "node_selected",
+                node=node,
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="low",
+            )
 
         price_data: Dict[str, PriceData] = {}
         for label, cfg in self.pools.items():
@@ -195,7 +340,7 @@ class CrossDomainArb:
             except Exception as exc:  # pragma: no cover - dependency errors
                 logging.warning("price fetch failed: %s", exc)
                 log_error(STRATEGY_ID, str(exc), event="price_fetch")
-                METRICS["fails"] += 1
+                metrics.record_fail()
                 return None
             price_data[label] = data
             self.last_prices[label] = data.price
@@ -204,27 +349,35 @@ class CrossDomainArb:
         if any(d.block_age > int(os.getenv("PRICE_FRESHNESS_SEC", "30")) for d in price_data.values()):
             logging.warning("stale price detected")
             log_error(STRATEGY_ID, "stale price detected", event="stale_price")
-            METRICS["fails"] += 1
+            metrics.record_fail()
             return None
 
         prices = {k: d.price for k, d in price_data.items()}
         opp = self._detect_opportunity(prices)
         if opp:
+            profit = self._compute_profit(opp["buy"], opp["sell"], prices)
+            if profit <= 0:
+                metrics.record_fail()
+                return None
             if not self.capital_lock.trade_allowed():
                 msg = "capital lock: trade not allowed"
                 log_error(STRATEGY_ID, msg, event="capital_lock", risk_level="high")
-                _log({
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "strategy_id": STRATEGY_ID,
-                    "risk_level": "high",
-                    "event": "capital_lock",
-                    "error": msg,
-                })
+                LOG.log(
+                    "capital_lock",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="high",
+                    error=msg,
+                )
                 return None
 
-            METRICS["opportunities"] += 1
-            METRICS["spreads"].append(float(opp["spread"]))
-            _send_alert({"strategy": STRATEGY_ID, **opp})
+            if not self._check_l1_sandwich():
+                return None
+            self._process_intents()
+            self._execute_flashloan(str(opp["buy"]), str(opp["sell"]))
+
+            metrics.record_opportunity(float(opp["spread"]), profit, 0.0)
+            _send_alert({"strategy": STRATEGY_ID, **opp, "profit": profit})
 
             pre = os.getenv("CROSS_ARB_STATE_PRE", "state/cross_arb_pre.json")
             post = os.getenv("CROSS_ARB_STATE_POST", "state/cross_arb_post.json")
@@ -234,11 +387,21 @@ class CrossDomainArb:
                 Path(p).parent.mkdir(parents=True, exist_ok=True)
             self.snapshot(pre)
             self.tx_builder.snapshot(tx_pre)
-            tx_hash = self.tx_builder.send_transaction(self.sample_tx, self.executor, strategy_id=STRATEGY_ID, mutation_id=os.getenv("MUTATION_ID", "dev"), risk_level="low")
+            start_time = datetime.now(timezone.utc)
+            tx_hash = self.tx_builder.send_transaction(
+                self.sample_tx,
+                self.executor,
+                strategy_id=STRATEGY_ID,
+                mutation_id=os.getenv("MUTATION_ID", "dev"),
+                risk_level="low",
+            )
+            latency = (datetime.now(timezone.utc) - start_time).total_seconds()
+            if self.node_selector:
+                node = self.node_selector.best()
+                self.node_selector.record(node, True, latency)
             self.tx_builder.snapshot(tx_post)
             self.snapshot(post)
 
-            profit = prices[opp["sell"]] - prices[opp["buy"]]
             self.capital_lock.record_trade(profit)
 
             for label, data in price_data.items():
@@ -249,9 +412,10 @@ class CrossDomainArb:
                     float(opp["spread"]),
                     str(opp["action"]),
                     tx_id=str(tx_hash),
+                    pnl=profit,
                 )
         else:
-            METRICS["fails"] += 1
+            metrics.record_fail()
 
         return opp
 
@@ -266,5 +430,13 @@ class CrossDomainArb:
         if "threshold" in params:
             try:
                 self.threshold = float(params["threshold"])
+                LOG.log(
+                    "mutate",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    param="threshold",
+                    value=self.threshold,
+                )
             except Exception as exc:  # pragma: no cover - input validation
                 log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")

--- a/tests/test_cross_domain_arb.py
+++ b/tests/test_cross_domain_arb.py
@@ -9,9 +9,12 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
-from strategies.cross_domain_arb import CrossDomainArb, PoolConfig
+from strategies.cross_domain_arb import CrossDomainArb, PoolConfig, BridgeConfig
+from core import metrics
 from agents.capital_lock import CapitalLock
 from core.oracles.uniswap_feed import PriceData
+from core.oracles.intent_feed import IntentData
+from adapters.pool_scanner import PoolInfo
 
 
 class DummyPool:
@@ -80,7 +83,7 @@ def test_opportunity_detection():
         "arb": PoolConfig("0xpool", "arbitrum"),
         "opt": PoolConfig("0xpool", "optimism"),
     }
-    strat = CrossDomainArb(pools, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102, "optimism": 101})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
@@ -92,7 +95,7 @@ def test_opportunity_detection():
 
 def test_price_feed_error():
     pools = {"eth": PoolConfig("0xpool", "ethereum")}
-    strat = CrossDomainArb(pools, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.feed = DummyFeed({"ethereum": RuntimeError("rpc fail")})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
@@ -110,7 +113,7 @@ def test_no_false_positive_on_flip():
         "eth": PoolConfig("0xpool", "ethereum"),
         "arb": PoolConfig("0xpool", "arbitrum"),
     }
-    strat = CrossDomainArb(pools, threshold=0.05, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, threshold=0.05, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 99})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
@@ -127,7 +130,7 @@ def test_no_false_positive_on_flip():
 
 def test_stale_block_warning(caplog):
     pools = {"eth": PoolConfig("0xpool", "ethereum")}
-    strat = CrossDomainArb(pools, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
     stale = PriceData(100, "0xpool", 1, 1, 31)
     strat.feed = DummyFeed({"ethereum": 100})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
@@ -146,7 +149,7 @@ def test_stale_block_warning(caplog):
 
 def test_snapshot_restore(tmp_path):
     pools = {"eth": PoolConfig("0xpool", "ethereum")}
-    strat = CrossDomainArb(pools, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.last_prices = {"eth": 1.23}
     snap = tmp_path / "snap.json"
     strat.snapshot(snap)
@@ -162,7 +165,7 @@ def test_multiple_opportunities(tmp_path):
         "eth": PoolConfig("0xpool", "ethereum"),
         "arb": PoolConfig("0xpool", "arbitrum"),
     }
-    strat = CrossDomainArb(pools, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 103})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
@@ -181,18 +184,58 @@ def test_multiple_opportunities(tmp_path):
     assert Path(os.environ["CROSS_ARB_TX_POST"]).exists()
 
 
+def test_bridge_cost_blocks_trade():
+    pools = {
+        "eth": PoolConfig("0xpool", "ethereum"),
+        "arb": PoolConfig("0xpool", "arbitrum"),
+    }
+    bridges = {("ethereum", "arbitrum"): BridgeConfig(cost=0.1)}
+    strat = CrossDomainArb(pools, bridges, threshold=0.001, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 100.05})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+    result = strat.run_once()
+    assert result is None
+
+
+def test_alert_metric_increment(monkeypatch):
+    pools = {
+        "eth": PoolConfig("0xpool", "ethereum"),
+        "arb": PoolConfig("0xpool", "arbitrum"),
+    }
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
+    metrics._METRICS["alert_count"] = 0
+    class DummyReq:
+        @staticmethod
+        def post(url, json=None, timeout=5):
+            return None
+
+    monkeypatch.setattr("strategies.cross_domain_arb.strategy.requests", DummyReq)
+    monkeypatch.setenv("ARB_ALERT_WEBHOOK", "http://localhost")
+    strat.run_once()
+    assert metrics._METRICS["alert_count"] == 1
+
+
 def test_mutate_hook(tmp_path):
     pools = {"eth": PoolConfig("0xpool", "ethereum")}
-    strat = CrossDomainArb(pools, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
     assert strat.threshold == 0.01
     strat.mutate({"threshold": 0.02})
     assert strat.threshold == 0.02
 
 
 def test_drp_snapshots(tmp_path):
-    pools = {"eth": PoolConfig("0xpool", "ethereum")}
-    strat = CrossDomainArb(pools, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0))
-    strat.feed = DummyFeed({"ethereum": 100})
+    pools = {
+        "eth": PoolConfig("0xpool", "ethereum"),
+        "arb": PoolConfig("0xpool", "arbitrum"),
+    }
+    strat = CrossDomainArb(pools, {}, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 101})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
@@ -205,3 +248,130 @@ def test_drp_snapshots(tmp_path):
     assert Path(os.environ["CROSS_ARB_STATE_POST"]).exists()
     assert Path(os.environ["CROSS_ARB_TX_PRE"]).exists()
     assert Path(os.environ["CROSS_ARB_TX_POST"]).exists()
+
+class DummyMempoolMonitor:
+    def __init__(self, txs):
+        self.txs = txs
+    def listen_bridge_txs(self, limit=10):
+        return iter(self.txs)
+
+class DummyIntentFeed:
+    def __init__(self, intents):
+        self.intents = intents
+    def fetch_intents(self, domain):
+        return [IntentData(**i) for i in self.intents.get(domain, [])]
+
+class DummyNodeSelector:
+    def __init__(self):
+        self.called = False
+    def best(self):
+        self.called = True
+        return "node1"
+    def record(self, node, success, latency):
+        self.recorded = (node, success)
+
+class DummyFlashloan:
+    def __init__(self):
+        self.called = False
+    def trigger(self, token, amount):
+        self.called = True
+        return {"tx": "0x1"}
+
+class DummyScanner:
+    def __init__(self, pools):
+        self.pools = pools
+    def scan(self):
+        return self.pools
+
+
+def test_sandwich_execution(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum"), "arb": PoolConfig("0xpool", "arbitrum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    calls = []
+    strat.tx_builder.send_transaction = lambda *a, **k: calls.append(True) or b"h"
+    strat.mempool_monitor = DummyMempoolMonitor([{"hash": "0xbridge"}])
+    strat.run_once()
+    assert len(calls) >= 3  # sandwich + trade
+
+
+def test_intent_classification(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"h"
+    strat.intent_feed = DummyIntentFeed({"eth": [{"intent_id": "1", "domain": "eth", "action": "swap", "price": 1}]})
+    monkeypatch.setattr("ai.intent_classifier.classify_intent", lambda x: "arb")
+    strat.run_once()
+    # log check not needed; absence of error implies call
+
+
+def test_node_selector(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.0, nodes={"node1": ""}, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"h"
+    ns = DummyNodeSelector()
+    strat.node_selector = ns
+    strat.run_once()
+    assert ns.called
+
+
+def test_flashloan_trigger(monkeypatch):
+    pools = {
+        "eth": PoolConfig("0xpool", "ethereum"),
+        "arb": PoolConfig("0xpool", "arbitrum"),
+    }
+    strat = CrossDomainArb(pools, {}, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0), edges_enabled={"flashloan": True})
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"h"
+    fl = DummyFlashloan()
+    strat.flashloan = fl
+    strat.run_once()
+    assert fl.called
+
+
+def test_auto_discover(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"h"
+    strat.pool_scanner = DummyScanner([PoolInfo("0xnew", "arbitrum")])
+    strat.run_once()
+    assert "0xnew" in strat.pools
+
+
+def test_bridge_failure(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum"), "arb": PoolConfig("0xpool", "arbitrum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    def fail(*a, **k):
+        raise RuntimeError("tx fail")
+    strat.tx_builder.send_transaction = fail
+    strat.mempool_monitor = DummyMempoolMonitor([{"hash": "0xbridge"}])
+    result = strat.run_once()
+    assert result is None
+
+
+def test_alpha_decay(monkeypatch):
+    pools = {"eth": PoolConfig("0xpool", "ethereum"), "arb": PoolConfig("0xpool", "arbitrum")}
+    strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102})
+    strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
+    strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]
+    strat.tx_builder.send_transaction = lambda *a, **k: b"h"
+    strat._compute_profit = lambda *a, **k: -1
+    result = strat.run_once()
+    assert result is None

--- a/tests/test_export_state_sh.py
+++ b/tests/test_export_state_sh.py
@@ -90,10 +90,6 @@ def test_export_encrypted(tmp_path):
 
 
     env = os.environ.copy()
-    env.update({
-        "EXPORT_DIR": str(export_dir),
-        "EXPORT_LOG_FILE": str(log_file),
-
     env.update(
         {
             "EXPORT_DIR": str(export_dir),


### PR DESCRIPTION
## Summary
- upgrade cross domain arb strategy with L1 mempool sandwich logic and intent-based routing
- integrate node performance tracking, flashloan adapter, and pool scanner
- add mempool monitor, node selector, and intent classifier modules
- expand tests for sandwich execution, intent classification, node selection, flashloan trigger, auto discovery, bridge failure, and alpha decay

## Testing
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: connection refused)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`
