### PR TITLE
Add alpha dashboard and meta orchestrator features

### DIFF
--- a/ai/mutation_log.py
+++ b/ai/mutation_log.py
@@ -1,0 +1,15 @@
+"""Mutation log utilities for agent evolution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import os
+from core.logger import StructuredLogger
+
+LOG = StructuredLogger("mutation_log", log_file=os.getenv("MUTATION_LOG", "logs/mutation_log.json"))
+
+
+def log_mutation(event: str, **data: Any) -> None:
+    """Append a mutation event entry."""
+    LOG.log(event, **data)

--- a/ai/mutator/prune.py
+++ b/ai/mutator/prune.py
@@ -18,6 +18,7 @@ import os
 from typing import Any, Dict, List
 
 from core.logger import StructuredLogger
+from ai.mutation_log import log_mutation
 
 LOGGER = StructuredLogger("strategy_prune")
 
@@ -49,5 +50,11 @@ def prune_strategies(metrics: Dict[str, Dict[str, Any]], audit_feedback: Dict[st
                 risk_level="high",
                 error=None,
                 info={"pnl": pnl, "risk": risk, "chaos_fail": chaos_fail, "audit_fail": audit_fail},
+            )
+            log_mutation(
+                "prune_strategy",
+                strategy_id=sid,
+                before={"pnl": pnl, "risk": risk},
+                reason="decayed_alpha" if pnl <= 0 else "high_risk",
             )
     return flagged

--- a/core/alpha_dashboard.py
+++ b/core/alpha_dashboard.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Lightweight Alpha/PnL dashboard using Flask.
+
+This server exposes a JSON endpoint with recent performance data
+for live strategies. It is intended for founder/ops monitoring and
+runs independently from the core orchestrator.
+"""
+
+import os
+from threading import Thread
+from typing import Any, Dict
+
+try:
+    from flask import Flask, jsonify  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    Flask = None  # type: ignore
+    jsonify = lambda x: x  # type: ignore
+
+
+class AlphaDashboard:
+    """Serve runtime strategy status via ``/status``."""
+
+    def __init__(self, orchestrator: Any, port: int | None = None) -> None:
+        self.orchestrator = orchestrator
+        self.port = int(os.getenv("DASHBOARD_PORT", port or 8501))
+        if Flask is not None:
+            self.app = Flask(__name__)
+            self.app.add_url_rule("/status", "status", self._status)
+        else:
+            self.app = None
+        self.thread: Thread | None = None
+
+    # --------------------------------------------------------------
+    def status_data(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"strategies": {}}
+        if hasattr(self.orchestrator, "status"):
+            data["orchestrator"] = self.orchestrator.status()
+        strategies = getattr(self.orchestrator, "strategies", {})
+        for sid, strat in strategies.items():
+            trades = getattr(strat.capital_lock, "trades", [])
+            pnl = sum(trades)
+            wins = sum(1 for t in trades if t > 0)
+            losses = sum(1 for t in trades if t <= 0)
+            pools = [cfg.pool for cfg in getattr(strat, "pools", {}).values()]
+            stealth = strat.edges_enabled.get("stealth_mode", False)
+            data["strategies"][sid] = {
+                "pnl": pnl,
+                "wins": wins,
+                "losses": losses,
+                "pools": pools,
+                "stealth_mode": stealth,
+            }
+        return data
+
+    # --------------------------------------------------------------
+    def _status(self) -> Any:  # pragma: no cover - HTTP wrapper
+        return jsonify(self.status_data())
+
+    # --------------------------------------------------------------
+    def start(self) -> None:
+        if self.app is None or Flask is None:
+            return
+        self.thread = Thread(
+            target=self.app.run,
+            kwargs={"host": "0.0.0.0", "port": self.port},
+            daemon=True,
+        )
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        if self.thread:
+            try:
+                from werkzeug.serving import make_server
+
+                server = make_server("0.0.0.0", self.port, self.app)
+                server.shutdown()  # pragma: no cover - manual
+            except Exception:
+                pass
+            self.thread = None

--- a/core/meta_orchestrator.py
+++ b/core/meta_orchestrator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Meta-orchestrator running multiple strategy variants."""
+
+import random
+from typing import Any, Dict, Type
+
+from core.logger import StructuredLogger
+from ai.mutation_log import log_mutation
+
+
+class MetaOrchestrator:
+    """Spawn, score and prune strategy variants."""
+
+    def __init__(self, strategy_cls: Type[Any], base_params: Dict[str, Any], num_agents: int = 2) -> None:
+        self.strategy_cls = strategy_cls
+        self.base_params = base_params
+        self.num_agents = num_agents
+        self.active_agents: Dict[int, Any] = {}
+        self.pruned_agents: list[int] = []
+        self.logger = StructuredLogger("meta_orchestrator")
+        self._spawn_agents(self.num_agents)
+
+    # --------------------------------------------------------------
+    def _spawn_agents(self, n: int) -> None:
+        for _ in range(n):
+            params = self.base_params.copy()
+            params["threshold"] = params.get("threshold", 0.003) * (0.9 + 0.2 * random.random())
+            aid = max(self.active_agents.keys(), default=-1) + 1
+            agent = self.strategy_cls(**params)
+            self.active_agents[aid] = agent
+            log_mutation("spawn_variant", agent_id=aid, params=params)
+
+    # --------------------------------------------------------------
+    def run_cycle(self) -> None:
+        for agent in self.active_agents.values():
+            try:
+                agent.run_once()
+            except Exception:
+                continue
+        scores = {aid: getattr(agent, "evaluate_pnl", lambda: 0.0)() for aid, agent in self.active_agents.items()}
+        keep = sorted(scores, key=scores.get, reverse=True)[: max(1, self.num_agents // 2)]
+        pruned = [aid for aid in list(self.active_agents) if aid not in keep]
+        for aid in pruned:
+            log_mutation("pruned_agent", agent_id=aid, pnl=scores.get(aid, 0.0), reason="low_performance")
+            self.pruned_agents.append(aid)
+            del self.active_agents[aid]
+        if pruned:
+            self._spawn_agents(len(pruned))
+        self.logger.log("cycle", active=list(self.active_agents), pruned=pruned)
+
+    # --------------------------------------------------------------
+    def status(self) -> Dict[str, Any]:
+        return {"active_agents": list(self.active_agents), "pruned_agents": self.pruned_agents}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pytest
 hexbytes
 requests
 flake8
+# dashboard
+flask
 # Flashbots bundle submission
 flashbots
 # Add any others your code imports

--- a/scripts/replay_arms_race.py
+++ b/scripts/replay_arms_race.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Replay historical MEV transactions for benchmarking."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ai.mutation_log import log_mutation
+
+
+def load_txs(path: str) -> List[Dict[str, Any]]:
+    data = json.loads(Path(path).read_text())
+    return data if isinstance(data, list) else []
+
+
+def replay(txs: List[Dict[str, Any]]) -> Dict[str, int]:
+    wins = 0
+    losses = 0
+    for tx in txs:
+        if float(tx.get("profit", 0)) > 0:
+            wins += 1
+        else:
+            losses += 1
+    log_mutation(
+        "arms_race", wins=wins, losses=losses, total=len(txs)
+    )
+    return {"wins": wins, "losses": losses}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Replay arms race transactions")
+    p.add_argument("--log", required=True, help="JSON file with tx data")
+    args = p.parse_args()
+    stats = replay(load_txs(args.log))
+    print(json.dumps(stats))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -47,6 +47,7 @@ from adapters.flashloan_adapter import FlashloanAdapter
 from adapters.pool_scanner import PoolScanner, PoolInfo
 from adapters.social_alpha import scrape_social_keywords
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from ai.mutation_log import log_mutation
 
 LOG_FILE = Path(os.getenv("CROSS_ARB_LOG", "logs/cross_domain_arb.json"))
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -532,6 +533,7 @@ class CrossDomainArb:
 
         if "threshold" in params:
             try:
+                old = self.threshold
                 self.threshold = float(params["threshold"])
                 LOG.log(
                     "mutate",
@@ -540,6 +542,13 @@ class CrossDomainArb:
                     risk_level="low",
                     param="threshold",
                     value=self.threshold,
+                )
+                log_mutation(
+                    "param_mutation",
+                    strategy_id=STRATEGY_ID,
+                    param="threshold",
+                    before=old,
+                    after=self.threshold,
                 )
             except Exception as exc:  # pragma: no cover - input validation
                 log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")

--- a/tests/test_alpha_dashboard.py
+++ b/tests/test_alpha_dashboard.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from core.alpha_dashboard import AlphaDashboard
+from agents.capital_lock import CapitalLock
+from strategies.cross_domain_arb import PoolConfig, CrossDomainArb
+
+
+class DummyOrch:
+    def __init__(self):
+        pools = {"eth": PoolConfig("0xpool", "ethereum")}
+        strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
+        self.strategies = {"dummy": strat}
+
+    def status(self):
+        return {"active_agents": [0], "pruned_agents": []}
+
+
+def test_status_data():
+    orch = DummyOrch()
+    dash = AlphaDashboard(orch)
+    data = dash.status_data()
+    assert "dummy" in data["strategies"]
+    assert data["orchestrator"]["active_agents"] == [0]

--- a/tests/test_intent_classifier_live.py
+++ b/tests/test_intent_classifier_live.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from ai import intent_classifier
+
+
+def test_live_classifier_fallback(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("INTENT_CLASSIFIER_LIVE", "1")
+    res = intent_classifier.classify_intent({"intent_id": "1", "domain": "eth"})
+    assert res == "eth"

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from core.meta_orchestrator import MetaOrchestrator
+
+
+class Dummy:
+    def __init__(self, threshold=0.1):
+        self.threshold = threshold
+        self.capital_lock = type("L", (), {"trades": [1.0]})()
+        self.pools = {}
+        self.edges_enabled = {"stealth_mode": False}
+
+    def run_once(self):
+        pass
+
+    def evaluate_pnl(self):
+        return self.threshold
+
+
+def test_meta_cycle():
+    orch = MetaOrchestrator(Dummy, {"threshold": 0.1}, num_agents=2)
+    orch.run_cycle()
+    st = orch.status()
+    assert st["active_agents"]

--- a/tests/test_mutation_log.py
+++ b/tests/test_mutation_log.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from ai.mutation_manager import MutationManager
+from ai import mutation_log
+
+
+class Dummy:
+    def __init__(self, threshold=0.1):
+        self.threshold = threshold
+    def evaluate_pnl(self):
+        return self.threshold
+
+
+def test_mutation_logging(tmp_path, monkeypatch):
+    log = tmp_path / "mutation_log.json"
+    monkeypatch.setenv("MUTATION_LOG", str(log))
+    monkeypatch.setenv("PYTHONHASHSEED", "0")
+    import importlib
+    import ai.mutation_log
+    importlib.reload(ai.mutation_log)
+    from ai.mutation_log import log_mutation  # noqa: E402
+    mm = MutationManager({"threshold": 0.1}, num_agents=2)
+    mm.spawn_agents(Dummy)
+    mm.score_and_prune()
+    assert log.exists()
+    entries = [json.loads(line) for line in log.read_text().splitlines()]
+    assert any(e["event"].startswith("spawn") for e in entries)

--- a/tests/test_replay_arms_race.py
+++ b/tests/test_replay_arms_race.py
@@ -1,0 +1,20 @@
+import json
+import subprocess
+from pathlib import Path
+import sys
+import os
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "replay_arms_race.py"
+
+
+def test_replay(tmp_path):
+    data = [{"hash": "0x1", "profit": 1}, {"hash": "0x2", "profit": -1}]
+    log = tmp_path / "txs.json"
+    log.write_text(json.dumps(data))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    res = subprocess.run([sys.executable, str(SCRIPT), "--log", str(log)], capture_output=True, text=True, env=env, check=True)
+    out = json.loads(res.stdout.strip())
+    assert out["wins"] == 1


### PR DESCRIPTION
## Summary
- add Flask-based alpha dashboard with `/status` endpoint
- upgrade intent classifier with OpenAI integration and feature flag
- track mutations with new log file
- implement meta orchestrator for scoring/pruning strategy variants
- add arms race replay script and meta tests
- update cross-domain arb strategy mutation logging
- extend test suite for dashboard, classifier, orchestrator, mutation log, and replay
- add Flask to requirements

## Testing
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: connection refused)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`