### PR TITLE
Add missing pytest import and fix DRP export test syntax

### DIFF
--- a/tests/test_export_state_sh.py
+++ b/tests/test_export_state_sh.py
@@ -93,11 +93,9 @@ def test_export_encrypted(tmp_path):
     env.update({
         "EXPORT_DIR": str(export_dir),
         "EXPORT_LOG_FILE": str(log_file),
-
         "PWD": str(tmp_path),
         "DRP_ENC_KEY": "secret",
         "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
-      ]
     })
     os.chdir(tmp_path)
 

--- a/tests/test_rollback_sh.py
+++ b/tests/test_rollback_sh.py
@@ -5,6 +5,7 @@ import json
 import shutil
 import io
 from pathlib import Path
+import pytest
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "rollback.sh"
 


### PR DESCRIPTION
## Summary
- add missing pytest import in rollback tests
- fix bracket typo in export_state_sh tests

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: connection refused)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/export_state.json` *(fails: ModuleNotFoundError)*