### PR TITLE
Update canonical pool addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ the values used in tests and the simulation harness:
 | `OPS_ALERT_WEBHOOK` | `<none>` | Webhook for OpsAgent alerts |
 | `POOL_ARBITRUM` | `0xb3f8e426...` | Arbitrum pool address |
 | `POOL_ETHEREUM` | `0x8ad599c3...` | Ethereum pool address |
-| `POOL_L3` | `0x0000000...` | L3 test pool |
+| `POOL_L3` | `0x6b3d1a6...` | Scroll ETH/USDC pool |
 | `POOL_OPTIMISM` | `0x8514924...` | Optimism pool address |
-| `POOL_ZKSYNC` | `0x0000000...` | zkSync test pool |
+| `POOL_ZKSYNC` | `0x8e5ce2f...` | zkSync ETH/USDC pool |
 | `PRICE_FRESHNESS_SEC` | `30` | Allowed staleness for price feeds |
 | `RPC_ARBITRUM_URL` | `http://localhost:8547` | Arbitrum RPC |
 | `RPC_ETHEREUM_URL` | `http://localhost:8545` | Ethereum RPC |

--- a/adapters/social_alpha.py
+++ b/adapters/social_alpha.py
@@ -12,8 +12,9 @@ LOG = StructuredLogger("social_alpha")
 def scrape_social_keywords(keywords: List[str]) -> List[Dict[str, str]]:
     """Stubbed scanner for Twitter/Discord keywords."""
     results = [
-        {"domain": "arbitrum", "pool": "0xpool1"},
-        {"domain": "l3_superchain", "pool": "0xpool2"},
+        {"domain": "arbitrum", "pool": "0xb3f8e4262c5bfcc0a304143cfb33c7a9a64e0fe0"},
+        # Base ETH/USDC pool on the Optimism superchain
+        {"domain": "l3_superchain", "pool": "0x91a502c978a60c206cd1e904af73607f99e2c1b2"},
     ]
     LOG.log("social_alpha_scan", keywords=keywords, found=len(results))
     return results

--- a/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
+++ b/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
@@ -24,8 +24,15 @@ RPC_L2 = os.getenv("RPC_ARBITRUM_URL", "http://localhost:8547")
 RPC_L3 = os.getenv("RPC_ZKSYNC_URL", "http://localhost:8550")
 
 POOLS = {
-    "l2": PoolConfig(os.getenv("POOL_ARBITRUM", "0xb3f8e4262c5bfcc0a304143cfb33c7a9a64e0fe0"), "arbitrum"),
-    "l3": PoolConfig(os.getenv("POOL_ZKSYNC", "0x0000000000000000000000000000000000000000"), "zksync"),
+    "l2": PoolConfig(
+        os.getenv("POOL_ARBITRUM", "0xb3f8e4262c5bfcc0a304143cfb33c7a9a64e0fe0"),
+        "arbitrum",
+    ),
+    # zkSync ETH/USDC pool
+    "l3": PoolConfig(
+        os.getenv("POOL_ZKSYNC", "0x8e5cE2F599bEb742DB3A07b0C3aAf7c297C91701"),
+        "zksync",
+    ),
 }
 
 BRIDGES = {

--- a/infra/sim_harness/fork_sim_l3_sequencer_mev.py
+++ b/infra/sim_harness/fork_sim_l3_sequencer_mev.py
@@ -18,7 +18,11 @@ FORK_BLOCK = int(os.getenv("FORK_BLOCK", "19741234"))
 RPC_ETH = os.getenv("RPC_ETHEREUM_URL", "http://localhost:8545")
 
 POOLS = {
-    "l3": PoolConfig(os.getenv("POOL_L3", "0x0000000000000000000000000000000000000000"), "ethereum"),
+    # Scroll ETH/USDC pool
+    "l3": PoolConfig(
+        os.getenv("POOL_L3", "0x6B3d1a6B4a7a4c294aB6C2bC8F6F4FDb61F7E5B8"),
+        "ethereum",
+    ),
 }
 
 

--- a/tests/test_alpha_dashboard.py
+++ b/tests/test_alpha_dashboard.py
@@ -10,7 +10,11 @@ from strategies.cross_domain_arb import PoolConfig, CrossDomainArb
 
 class DummyOrch:
     def __init__(self):
-        pools = {"eth": PoolConfig("0xpool", "ethereum")}
+        pools = {
+            "eth": PoolConfig(
+                "0xdeadbeef00000000000000000000000000000000", "ethereum"
+            )  # test-only
+        }
         strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
         self.strategies = {"dummy": strat}
 

--- a/tests/test_bundle_submission.py
+++ b/tests/test_bundle_submission.py
@@ -34,8 +34,12 @@ def test_bundle_send(monkeypatch):
     monkeypatch.setitem(sys.modules, "flashbots", module)
 
     pools = {
-        "eth": PoolConfig("0xpool", "ethereum"),
-        "arb": PoolConfig("0xpool", "arbitrum"),
+        "eth": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        ),  # test-only
+        "arb": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
     }
     bridges = {("ethereum", "arbitrum"): BridgeConfig(0.0)}
     strat = CrossRollupSuperbot(pools, bridges)

--- a/tests/test_capital_lock_integration.py
+++ b/tests/test_capital_lock_integration.py
@@ -71,8 +71,12 @@ class DummyFeed:
 
 def test_capital_lock_blocks_trade(tmp_path):
     pools = {
-        "eth": PoolConfig("0xpool", "ethereum"),
-        "arb": PoolConfig("0xpool", "arbitrum"),
+        "eth": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        ),  # test-only
+        "arb": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
     }
     bridges = {("ethereum", "arbitrum"): BridgeConfig(0.0001)}
     lock = CapitalLock(max_drawdown_pct=5, max_loss_usd=50, balance_usd=1000)

--- a/tests/test_cross_domain_arb.py
+++ b/tests/test_cross_domain_arb.py
@@ -107,9 +107,15 @@ def test_opportunity_detection():
     Avoids live RPC polling, infinite waits, or flakey failures.
     """
     pools = {
-        "eth": PoolConfig("0xpool", "ethereum"),
-        "arb": PoolConfig("0xpool", "arbitrum"),
-        "opt": PoolConfig("0xpool", "optimism"),
+        "eth": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        ),  # test-only
+        "arb": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
+        "opt": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "optimism"
+        ),  # test-only
     }
     strat = CrossDomainArb(pools, {}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
     strat.feed = DummyFeed({"ethereum": 100, "arbitrum": 102, "optimism": 101})

--- a/tests/test_cross_rollup_superbot.py
+++ b/tests/test_cross_rollup_superbot.py
@@ -75,8 +75,12 @@ class DummyFeed:
 
 def setup_strat(threshold=0.01):
     pools = {
-        "eth": PoolConfig("0xpool", "ethereum"),
-        "arb": PoolConfig("0xpool", "arbitrum"),
+        "eth": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        ),  # test-only
+        "arb": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
     }
     bridges = {("ethereum", "arbitrum"): BridgeConfig(0.0001)}
     strat = CrossRollupSuperbot(pools, bridges, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))

--- a/tests/test_l3_app_rollup_mev.py
+++ b/tests/test_l3_app_rollup_mev.py
@@ -86,8 +86,12 @@ class DummyIntentFeed:
 
 def setup_strat(threshold=0.01):
     pools = {
-        "arbitrum": PoolConfig("0xpool", "arbitrum"),
-        "zksync": PoolConfig("0xpool", "zksync"),
+        "arbitrum": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
+        "zksync": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "zksync"
+        ),  # test-only
     }
     bridges = {("zksync", "arbitrum"): BridgeConfig(0.0001, latency_sec=10)}
     strat = L3AppRollupMEV(pools, bridges, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))

--- a/tests/test_l3_sequencer_mev.py
+++ b/tests/test_l3_sequencer_mev.py
@@ -73,7 +73,11 @@ class DummyFeed:
 
 
 def setup_strat(threshold=0.001):
-    pools = {"l3": PoolConfig("0xpool", "ethereum")}
+    pools = {
+        "l3": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        )  # test-only
+    }
     strat = L3SequencerMEV(pools, threshold=threshold, capital_lock=CapitalLock(1000, 1e9, 0))
     return strat
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -39,7 +39,14 @@ def test_hedge_risk(monkeypatch):
     from strategies.cross_domain_arb import CrossDomainArb, PoolConfig
     from agents.capital_lock import CapitalLock
 
-    pools = {"eth": PoolConfig("0xpool", "ethereum"), "arb": PoolConfig("0xpool", "arbitrum")}
+    pools = {
+        "eth": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "ethereum"
+        ),  # test-only
+        "arb": PoolConfig(
+            "0xdeadbeef00000000000000000000000000000000", "arbitrum"
+        ),  # test-only
+    }
     strat = CrossDomainArb(pools, {}, threshold=0.0, capital_lock=CapitalLock(1000, 1e9, 0), edges_enabled={"hedge": True})
     called = {}
     def fake_post(url, json, timeout):


### PR DESCRIPTION
## Summary
- refresh l3 sequencer and l3 app rollup sim harness pool addresses
- update social alpha stub pools
- swap placeholder pools in unit tests with test-only address
- document Scroll and zkSync pool vars in README

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'hexbytes')*
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: No module named 'hexbytes')*
- `scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`