### PR TITLE
Improve nonce handling with shared manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ SOCIAL_ALPHA_ENABLED=false
 # -------------------------
 WALLET_OPS_LOG=./logs/wallet_ops.log
 BATCH_OPS_CONFIG= # Optional batch ops config file
+NONCE_CACHE_FILE=state/nonce_cache.json
+NONCE_LOG_FILE=logs/nonce_log.json
 
 # -------------------------
 # Strategy Parameters (example)

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ the values used in tests and the simulation harness:
 | `SUPERBOT_STATE_PRE` | `state/superbot_pre.json` | Pre DRP snapshot |
 | `SUPERBOT_TX_POST` | `state/superbot_tx_post.json` | Tx builder post snapshot |
 | `SUPERBOT_TX_PRE` | `state/superbot_tx_pre.json` | Tx builder pre snapshot |
+| `NONCE_CACHE_FILE` | `state/nonce_cache.json` | NonceManager cache |
+| `NONCE_LOG_FILE` | `logs/nonce_log.json` | NonceManager audit log |
 | `TX_LOG_FILE` | `logs/tx_log.json` | Transaction builder log |
 | `ORCH_CONFIG` | `config.yaml` | Orchestrator config file |
 | `ORCH_LOGS_DIR` | `logs` | Directory for orchestrator logs |

--- a/core/meta_orchestrator.py
+++ b/core/meta_orchestrator.py
@@ -6,6 +6,7 @@ import random
 from typing import Any, Dict, Type
 
 from core.logger import StructuredLogger
+from core.tx_engine.nonce_manager import get_shared_nonce_manager
 from ai.mutation_log import log_mutation
 
 
@@ -16,6 +17,7 @@ class MetaOrchestrator:
         self.strategy_cls = strategy_cls
         self.base_params = base_params
         self.num_agents = num_agents
+        self.nonce_manager = get_shared_nonce_manager()
         self.active_agents: Dict[int, Any] = {}
         self.pruned_agents: list[int] = []
         self.logger = StructuredLogger("meta_orchestrator")
@@ -26,6 +28,7 @@ class MetaOrchestrator:
         for _ in range(n):
             params = self.base_params.copy()
             params["threshold"] = params.get("threshold", 0.003) * (0.9 + 0.2 * random.random())
+            params["nonce_manager"] = self.nonce_manager
             aid = max(self.active_agents.keys(), default=-1) + 1
             agent = self.strategy_cls(**params)
             self.active_agents[aid] = agent

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -32,7 +32,7 @@ except Exception:  # pragma: no cover - allow missing dependency
     requests = None  # type: ignore
 
 from core.tx_engine.builder import TransactionBuilder, HexBytes
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.logger import StructuredLogger, log_error
 from core import metrics
 from agents.capital_lock import CapitalLock
@@ -110,6 +110,7 @@ class CrossDomainArb:
         nodes: Optional[Dict[str, str]] = None,
         edges_enabled: Optional[Dict[str, bool]] = None,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = UniswapV3Feed()
         self.pools = pools
@@ -121,7 +122,7 @@ class CrossDomainArb:
 
         # transaction execution setup
         w3 = self.feed.web3s.get("ethereum") if self.feed.web3s else None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("ARB_EXECUTOR_ADDR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/strategies/cross_rollup_superbot/strategy.py
+++ b/strategies/cross_rollup_superbot/strategy.py
@@ -34,7 +34,7 @@ from core.logger import StructuredLogger, log_error
 from core import metrics
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 
@@ -80,6 +80,7 @@ class CrossRollupSuperbot:
         threshold: float | None = None,
         *,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = UniswapV3Feed()
         self.pools = pools
@@ -92,7 +93,7 @@ class CrossRollupSuperbot:
         self.capital_lock = capital_lock or CapitalLock(1000.0, 1e9, 0.0)
 
         w3 = self.feed.web3s.get("ethereum") if self.feed.web3s else None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("SUPERBOT_EXECUTOR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -29,7 +29,7 @@ from core import metrics
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.oracles.intent_feed import IntentFeed, IntentData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 
@@ -76,6 +76,7 @@ class L3AppRollupMEV:
         threshold: float | None = None,
         edges_enabled: Optional[Dict[str, bool]] = None,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = UniswapV3Feed()
         self.intent_feed = IntentFeed()
@@ -94,7 +95,7 @@ class L3AppRollupMEV:
         self.capital_lock = capital_lock or CapitalLock(1000.0, 1e9, 0.0)
 
         w3 = self.feed.web3s.get("ethereum") if self.feed.web3s else None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("L3_APP_EXECUTOR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/strategies/l3_sequencer_mev/strategy.py
+++ b/strategies/l3_sequencer_mev/strategy.py
@@ -27,7 +27,7 @@ from core.logger import StructuredLogger, log_error
 from core import metrics
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 
@@ -66,6 +66,7 @@ class L3SequencerMEV:
         time_band_sec: int = 12,
         reorg_window: int = 1,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = UniswapV3Feed()
         self.pools = pools
@@ -76,7 +77,7 @@ class L3SequencerMEV:
         self.last_block = 0
 
         w3 = self.feed.web3s.get("ethereum") if self.feed.web3s else None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("L3_SEQ_EXECUTOR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/strategies/nft_liquidation/strategy.py
+++ b/strategies/nft_liquidation/strategy.py
@@ -26,7 +26,7 @@ from core.logger import StructuredLogger, log_error
 from core import metrics
 from core.oracles.nft_liquidation_feed import NFTLiquidationFeed, AuctionData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 
@@ -52,6 +52,7 @@ class NFTLiquidationMEV:
         *,
         discount: float | None = None,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = NFTLiquidationFeed()
         self.auctions = auctions
@@ -59,7 +60,7 @@ class NFTLiquidationMEV:
         self.last_seen: Dict[str, str] = {}
 
         w3 = None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("NFT_LIQ_EXECUTOR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -25,7 +25,7 @@ from core.logger import StructuredLogger, log_error
 from core import metrics
 from core.oracles.rwa_feed import RWAFeed, RWAData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
-from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 
@@ -59,6 +59,7 @@ class RWASettlementMEV:
         *,
         threshold: float | None = None,
         capital_lock: CapitalLock | None = None,
+        nonce_manager: NonceManager | None = None,
     ) -> None:
         self.feed = RWAFeed()
         self.venues = venues
@@ -66,7 +67,7 @@ class RWASettlementMEV:
         self.last_prices: Dict[str, float] = {}
 
         w3 = None
-        self.nonce_manager = NonceManager(w3)
+        self.nonce_manager = nonce_manager or get_shared_nonce_manager(w3)
         self.tx_builder = TransactionBuilder(w3, self.nonce_manager)
         self.executor = os.getenv("RWA_EXECUTOR", "0x0000000000000000000000000000000000000000")
         self.sample_tx = HexBytes(b"\x01")

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -1,6 +1,7 @@
 """Unit tests for the NonceManager."""
 
 import json
+import threading
 import sys
 from pathlib import Path
 
@@ -56,3 +57,53 @@ def test_cache_update_and_reset(tmp_path):
     logs = [json.loads(line) for line in log_file.read_text().splitlines()]
     assert logs[-1]["source"] == "get"
     assert logs[0]["source"] == "get"
+
+
+def test_concurrent_access(tmp_path):
+    cache = tmp_path / "cache.json"
+    log_file = tmp_path / "log.json"
+    w3 = DummyWeb3()
+    nm = NonceManager(w3, cache_file=str(cache), log_file=str(log_file))
+
+    results = []
+    def worker():
+        results.append(nm.get_nonce("0xabc"))
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sorted(results) == [5, 6, 7, 8, 9]
+
+
+def test_reset_increment_race(tmp_path):
+    cache = tmp_path / "cache.json"
+    log_file = tmp_path / "log.json"
+    w3 = DummyWeb3()
+    nm = NonceManager(w3, cache_file=str(cache), log_file=str(log_file))
+    nm.get_nonce("0xabc")
+
+    def do_get():
+        nm.get_nonce("0xabc")
+
+    def do_reset():
+        nm.reset_nonce("0xabc")
+
+    t1 = threading.Thread(target=do_get)
+    t2 = threading.Thread(target=do_reset)
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    final = nm.get_nonce("0xabc")
+    assert final >= 5
+
+
+def test_replay_attempt(tmp_path):
+    cache = tmp_path / "cache.json"
+    log_file = tmp_path / "log.json"
+    w3 = DummyWeb3()
+    nm = NonceManager(w3, cache_file=str(cache), log_file=str(log_file))
+    first = nm.get_nonce("0xabc")
+    nm.update_nonce("0xabc", first - 1)
+    assert nm.get_nonce("0xabc") == first


### PR DESCRIPTION
## Summary
- introduce global NonceManager and env vars `NONCE_CACHE_FILE`/`NONCE_LOG_FILE`
- inject shared nonce manager into orchestrator, meta orchestrator and strategies
- document new env vars in README and `.env.example`
- add concurrency, race and replay tests for NonceManager

## Testing
- `pytest tests/test_nonce_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: hexbytes)*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: web3 required)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json`