### PR TITLE
Ensure kill switch hard enforcement

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -124,7 +124,7 @@ class StrategyOrchestrator:
 
     # ---------------------------------------------------------------
     def run_once(self) -> bool:
-        if self.config.get("kill_switch_enabled", True) and kill_switch_triggered():
+        if kill_switch_triggered():
             record_kill_event("orchestrator")
             LOGGER.log("kill_switch", risk_level="high")
             return False

--- a/core/tx_engine/builder.py
+++ b/core/tx_engine/builder.py
@@ -24,7 +24,7 @@ import time
 from pathlib import Path
 from typing import Any, cast, SupportsIndex
 
-from .kill_switch import kill_switch_triggered, record_kill_event
+from . import kill_switch as ks
 from .nonce_manager import NonceManager
 from core.logger import log_error
 
@@ -102,8 +102,10 @@ class TransactionBuilder:
         """Send ``signed_tx`` with retry and kill switch checks."""
 
         tx_id = signed_tx.hex()
-        if kill_switch_triggered():
-            record_kill_event("TransactionBuilder")
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event("TransactionBuilder")
             entry = {
                 "tx_id": tx_id,
                 "from_address": from_address,

--- a/core/tx_engine/kill_switch.py
+++ b/core/tx_engine/kill_switch.py
@@ -58,5 +58,12 @@ def record_kill_event(origin: str) -> None:
     with lf.open("a") as f:
         json.dump(event, f)
         f.write("\n")
+    # also emit to generic error log for DRP visibility
+    try:
+        from core.logger import log_error
+
+        log_error(origin, "kill switch triggered", event="kill_switch", **event)
+    except Exception:
+        pass
 
 

--- a/scripts/kill_switch.sh
+++ b/scripts/kill_switch.sh
@@ -29,12 +29,15 @@ done
 ENV_FILE="${ENV_FILE:-.env}"
 FLAG_FILE="${KILL_SWITCH_FLAG_FILE:-./flags/kill_switch.txt}"
 LOG_FILE="${KILL_SWITCH_LOG_FILE:-/logs/kill_log.json}"
+ERROR_FILE="${ERROR_LOG_FILE:-logs/errors.log}"
 USER_NAME="$(whoami 2>/dev/null || echo unknown)"
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 log_event() {
     mkdir -p "$(dirname "$LOG_FILE")"
     printf '{"timestamp":"%s","mode":"%s","user":"%s","flag_file":"%s"}\n' "$TIMESTAMP" "$1" "$USER_NAME" "$FLAG_FILE" >> "$LOG_FILE"
+    mkdir -p "$(dirname "$ERROR_FILE")"
+    printf '{"timestamp":"%s","module":"kill_switch.sh","event":"%s","flag_file":"%s"}\n' "$TIMESTAMP" "$1" "$FLAG_FILE" >> "$ERROR_FILE"
 }
 
 if [[ $DRY -eq 1 ]]; then

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -46,7 +46,7 @@ from ai.intent_ghost import ghost_intent
 from adapters.flashloan_adapter import FlashloanAdapter
 from adapters.pool_scanner import PoolScanner
 from adapters.social_alpha import scrape_social_keywords
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from ai.mutation_log import log_mutation
 
 LOG_FILE = Path(os.getenv("CROSS_ARB_LOG", "logs/cross_domain_arb.json"))
@@ -409,8 +409,10 @@ class CrossDomainArb:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Dict[str, object]]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/strategies/cross_rollup_superbot/strategy.py
+++ b/strategies/cross_rollup_superbot/strategy.py
@@ -35,7 +35,7 @@ from core import metrics
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("CROSS_ROLLUP_LOG", "logs/cross_rollup_superbot.json"))
@@ -182,8 +182,10 @@ class CrossRollupSuperbot:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Opportunity]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -30,7 +30,7 @@ from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.oracles.intent_feed import IntentFeed, IntentData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("L3_APP_ROLLUP_LOG", "logs/l3_app_rollup_mev.json"))
@@ -212,8 +212,10 @@ class L3AppRollupMEV:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Opportunity]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/strategies/l3_sequencer_mev/strategy.py
+++ b/strategies/l3_sequencer_mev/strategy.py
@@ -28,7 +28,7 @@ from core import metrics
 from core.oracles.uniswap_feed import UniswapV3Feed, PriceData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("L3_SEQ_LOG", "logs/l3_sequencer_mev.json"))
@@ -174,8 +174,10 @@ class L3SequencerMEV:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Opportunity]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/strategies/nft_liquidation/strategy.py
+++ b/strategies/nft_liquidation/strategy.py
@@ -27,7 +27,7 @@ from core import metrics
 from core.oracles.nft_liquidation_feed import NFTLiquidationFeed, AuctionData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("NFT_LIQ_LOG", "logs/nft_liquidation.json"))
@@ -126,8 +126,10 @@ class NFTLiquidationMEV:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Dict[str, object]]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -26,7 +26,7 @@ from core import metrics
 from core.oracles.rwa_feed import RWAFeed, RWAData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager
-from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+from core.tx_engine import kill_switch as ks
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("RWA_SETTLE_LOG", "logs/rwa_settlement.json"))
@@ -137,8 +137,10 @@ class RWASettlementMEV:
 
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Opportunity]:
-        if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+        env_active = os.getenv("KILL_SWITCH") == "1"
+        file_active = Path(os.getenv("KILL_SWITCH_FLAG_FILE", "./flags/kill_switch.txt")).exists()
+        if env_active or file_active:
+            ks.record_kill_event(STRATEGY_ID)
             LOG.log(
                 "killed",
                 strategy_id=STRATEGY_ID,

--- a/tests/test_cross_rollup_superbot.py
+++ b/tests/test_cross_rollup_superbot.py
@@ -167,9 +167,7 @@ def test_kill_switch(monkeypatch):
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
-    monkeypatch.setattr(
-        "strategies.cross_rollup_superbot.strategy.kill_switch_triggered", lambda: True
-    )
+    monkeypatch.setenv("KILL_SWITCH", "1")
     result = strat.run_once()
     assert result is None
 

--- a/tests/test_kill_switch_bypass.py
+++ b/tests/test_kill_switch_bypass.py
@@ -1,0 +1,56 @@
+import json
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import pytest
+
+from core.tx_engine.builder import TransactionBuilder, HexBytes
+from core.tx_engine.nonce_manager import NonceManager
+from core.tx_engine import kill_switch as ks
+
+
+class DummyEth:
+    def __init__(self):
+        self.sent = []
+
+    def estimate_gas(self, tx):
+        return 21000
+
+    def get_transaction_count(self, address):
+        return 0
+
+    def send_raw_transaction(self, tx):
+        self.sent.append(tx)
+        return b"hash" + tx[-2:]
+
+    class account:
+        @staticmethod
+        def decode_transaction(tx):
+            return {}
+
+
+class DummyWeb3:
+    def __init__(self):
+        self.eth = DummyEth()
+
+
+def test_kill_switch_bypass_attempt(tmp_path, monkeypatch):
+    web3 = DummyWeb3()
+    nm = NonceManager(web3, cache_file=str(tmp_path / "nonce.json"))
+    builder = TransactionBuilder(web3, nm, log_path=tmp_path / "log.json")
+    kill_log = tmp_path / "kill.json"
+    err_log = tmp_path / "errors.log"
+    monkeypatch.setenv("KILL_SWITCH", "1")
+    monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(kill_log))
+    monkeypatch.setenv("ERROR_LOG_FILE", str(err_log))
+    monkeypatch.setattr(ks, "kill_switch_triggered", lambda: False)
+    with pytest.raises(RuntimeError):
+        builder.send_transaction(HexBytes(b"\x01"), "0xdef")
+    entries = [json.loads(line) for line in kill_log.read_text().splitlines()]
+    assert entries[-1]["origin_module"] == "TransactionBuilder"
+    err_lines = err_log.read_text().splitlines()
+    assert err_lines
+    monkeypatch.delenv("KILL_SWITCH")

--- a/tests/test_l3_app_rollup_mev.py
+++ b/tests/test_l3_app_rollup_mev.py
@@ -165,9 +165,7 @@ def test_kill_switch(monkeypatch):
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
-    monkeypatch.setattr(
-        "strategies.l3_app_rollup_mev.strategy.kill_switch_triggered", lambda: True
-    )
+    monkeypatch.setenv("KILL_SWITCH", "1")
     result = strat.run_once()
     assert result is None
 

--- a/tests/test_l3_sequencer_mev.py
+++ b/tests/test_l3_sequencer_mev.py
@@ -125,8 +125,6 @@ def test_kill_switch(monkeypatch):
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
-    monkeypatch.setattr(
-        "strategies.l3_sequencer_mev.strategy.kill_switch_triggered", lambda: True
-    )
+    monkeypatch.setenv("KILL_SWITCH", "1")
     result = strat.run_once()
     assert result is None

--- a/tests/test_nft_liquidation.py
+++ b/tests/test_nft_liquidation.py
@@ -90,8 +90,6 @@ def test_kill_switch(monkeypatch):
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
-    monkeypatch.setattr(
-        "strategies.nft_liquidation.strategy.kill_switch_triggered", lambda: True
-    )
+    monkeypatch.setenv("KILL_SWITCH", "1")
     result = strat.run_once()
     assert result is None

--- a/tests/test_rwa_settlement.py
+++ b/tests/test_rwa_settlement.py
@@ -98,8 +98,6 @@ def test_kill_switch(monkeypatch):
     strat.tx_builder.send_transaction = lambda *a, **k: b"hash"
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("KILL_SWITCH_LOG_FILE", str(Path(tmp) / "kill.json"))
-    monkeypatch.setattr(
-        "strategies.rwa_settlement.strategy.kill_switch_triggered", lambda: True
-    )
+    monkeypatch.setenv("KILL_SWITCH", "1")
     result = strat.run_once()
     assert result is None


### PR DESCRIPTION
## Summary
- enforce kill switch check in orchestrator and agents
- log kill switch events to `errors.log`
- update strategy modules to check env/file flags directly
- ensure kill switch script logs to `errors.log`
- add regression tests including bypass attempt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hexbytes')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: web3 required for fork simulation)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json` *(fails: ModuleNotFoundError: No module named 'core')*