### PR TITLE
Implement unified gatekeeper checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
           bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
           bash scripts/export_state.sh --dry-run
           python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+      - name: Check gates
+        run: python agents/check_gates.py
       - name: Promote
         if: env.FOUNDER_APPROVED == '1'
         run: echo "Founder approval received. Ready for production."

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['capital_lock', 'ops_agent', 'drp_agent', 'gatekeeper']

--- a/agents/check_gates.py
+++ b/agents/check_gates.py
@@ -1,0 +1,22 @@
+"""CLI helper to verify all agent gates are green."""
+
+from agents.capital_lock import CapitalLock
+from agents.ops_agent import OpsAgent
+from agents.drp_agent import DRPAgent
+from agents.gatekeeper import gates_green
+from agents.agent_registry import get_value
+
+
+def main() -> None:
+    lock = CapitalLock(0, 0, 0)
+    lock.blocked = bool(get_value("capital_locked", False))
+    ops = OpsAgent({})
+    ops.paused = bool(get_value("paused", False))
+    drp = DRPAgent()
+    drp.ready = bool(get_value("drp_ready", True))
+    if not gates_green(lock, ops, drp):
+        raise SystemExit("agent gates not green")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/agents/drp_agent.py
+++ b/agents/drp_agent.py
@@ -1,0 +1,32 @@
+"""Track DRP snapshot health for gating."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.logger import StructuredLogger
+from .agent_registry import set_value
+
+LOGGER = StructuredLogger("drp_agent")
+
+
+@dataclass
+class DRPAgent:
+    """Simple DRP health tracker."""
+
+    ready: bool = True
+
+    # --------------------------------------------------------------
+    def record_export(self, success: bool) -> None:
+        """Record DRP export result."""
+        self.ready = success
+        set_value("drp_ready", success)
+        if success:
+            LOGGER.log("export_ok", risk_level="low")
+        else:
+            LOGGER.log("export_fail", risk_level="high")
+
+    # --------------------------------------------------------------
+    def is_ready(self) -> bool:
+        """Return True if DRP is healthy."""
+        return self.ready

--- a/agents/gatekeeper.py
+++ b/agents/gatekeeper.py
@@ -1,0 +1,29 @@
+"""Aggregate agent gating logic."""
+
+from __future__ import annotations
+
+from core.logger import StructuredLogger
+from core.tx_engine.kill_switch import kill_switch_triggered
+from .capital_lock import CapitalLock
+from .ops_agent import OpsAgent
+from .drp_agent import DRPAgent
+
+LOGGER = StructuredLogger("gatekeeper")
+
+
+def gates_green(lock: CapitalLock, ops: OpsAgent, drp: DRPAgent) -> bool:
+    """Return ``True`` if all agent gates allow execution."""
+    if kill_switch_triggered():
+        LOGGER.log("kill_switch", risk_level="high")
+        return False
+    if not lock.trade_allowed():
+        LOGGER.log("capital_lock", risk_level="high")
+        return False
+    if ops.paused:
+        LOGGER.log("ops_paused", risk_level="high")
+        return False
+    if not drp.is_ready():
+        LOGGER.log("drp_not_ready", risk_level="high")
+        return False
+    LOGGER.log("all_green", risk_level="low")
+    return True

--- a/core/tx_engine/builder.py
+++ b/core/tx_engine/builder.py
@@ -27,6 +27,7 @@ from typing import Any, cast, SupportsIndex
 from .kill_switch import kill_switch_triggered, record_kill_event
 from .nonce_manager import NonceManager
 from core.logger import log_error
+from agents.agent_registry import get_value
 
 # simple HexBytes implementation
 class HexBytes(bytes):
@@ -125,6 +126,20 @@ class TransactionBuilder:
                 strategy_id=strategy_id,
             )
             raise RuntimeError("Kill switch active")
+
+        if (
+            get_value("paused", False)
+            or get_value("capital_locked", False)
+            or not get_value("drp_ready", True)
+        ):
+            log_error(
+                "TransactionBuilder",
+                "agent gates blocked",
+                tx_id=tx_id,
+                strategy_id=strategy_id,
+                event="gate_block",
+            )
+            raise RuntimeError("Agent gates blocked")
 
         # decode transaction for gas estimation
         try:

--- a/strategies/cross_rollup_superbot/strategy.py
+++ b/strategies/cross_rollup_superbot/strategy.py
@@ -37,6 +37,7 @@ from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
+import time
 
 LOG_FILE = Path(os.getenv("CROSS_ROLLUP_LOG", "logs/cross_rollup_superbot.json"))
 LOG = StructuredLogger("cross_rollup_superbot", log_file=str(LOG_FILE))

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -32,6 +32,7 @@ from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
+import time
 
 LOG_FILE = Path(os.getenv("L3_APP_ROLLUP_LOG", "logs/l3_app_rollup_mev.json"))
 LOG = StructuredLogger("l3_app_rollup_mev", log_file=str(LOG_FILE))

--- a/strategies/nft_liquidation/strategy.py
+++ b/strategies/nft_liquidation/strategy.py
@@ -28,6 +28,7 @@ from core.oracles.nft_liquidation_feed import NFTLiquidationFeed, AuctionData
 from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
+import time
 from agents.capital_lock import CapitalLock
 
 LOG_FILE = Path(os.getenv("NFT_LIQ_LOG", "logs/nft_liquidation.json"))

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -28,6 +28,7 @@ from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
+import time
 
 LOG_FILE = Path(os.getenv("RWA_SETTLE_LOG", "logs/rwa_settlement.json"))
 LOG = StructuredLogger("rwa_settlement", log_file=str(LOG_FILE))

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from agents.capital_lock import CapitalLock
+from agents.ops_agent import OpsAgent
+from agents.drp_agent import DRPAgent
+from agents.gatekeeper import gates_green
+import core.tx_engine.kill_switch as ks
+
+
+def _ops(paused=False):
+    agent = OpsAgent({})
+    agent.paused = paused
+    return agent
+
+
+def test_gates_all_green(monkeypatch):
+    monkeypatch.setattr(ks, "kill_switch_triggered", lambda: False)
+    lock = CapitalLock(0, 0, 0)
+    ops = _ops()
+    drp = DRPAgent()
+    assert gates_green(lock, ops, drp)
+
+
+def test_gate_blocks_on_failure(monkeypatch):
+    monkeypatch.setattr(ks, "kill_switch_triggered", lambda: True)
+    lock = CapitalLock(0, 0, 0)
+    ops = _ops()
+    drp = DRPAgent()
+    assert not gates_green(lock, ops, drp)
+
+    monkeypatch.setattr(ks, "kill_switch_triggered", lambda: False)
+    lock.blocked = True
+    assert not gates_green(lock, ops, drp)
+
+    lock.blocked = False
+    ops.paused = True
+    assert not gates_green(lock, ops, drp)
+
+    ops.paused = False
+    drp.ready = False
+    assert not gates_green(lock, ops, drp)

--- a/tests/test_ops_agent.py
+++ b/tests/test_ops_agent.py
@@ -15,3 +15,18 @@ def test_ops_health_fail(monkeypatch):
     agent.run_checks()
     assert any(e["event"] == "auto_pause" for e in captured)
 
+
+def test_notify_fail(monkeypatch):
+    agent = OpsAgent({})
+    captured = []
+    register_hook(lambda e: captured.append(e))
+    monkeypatch.setenv("OPS_ALERT_WEBHOOK", "http://x")
+
+    class DummyReq:
+        def post(self, *a, **k):
+            raise RuntimeError("fail")
+
+    monkeypatch.setitem(sys.modules, "requests", DummyReq())
+    agent.notify("hi")
+    assert any(e["event"] == "notify_fail" for e in captured)
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -84,6 +84,21 @@ def test_dry_run_snapshot(monkeypatch, tmp_path):
     assert any("--dry-run" in c for c in calls[0])
 
 
+def test_drp_partial_failure(monkeypatch, tmp_path):
+    _make_dummy_strategy(tmp_path)
+    cfg = _config(tmp_path)
+    orch = StrategyOrchestrator(str(cfg))
+    monkeypatch.setattr(
+        "core.orchestrator.StrategyOrchestrator._snapshot_state", lambda self: False
+    )
+    assert orch.run_once()
+    assert orch.drp_agent.ready is False
+    monkeypatch.setattr(
+        "core.orchestrator.StrategyOrchestrator._snapshot_state", lambda self: True
+    )
+    assert orch.run_once() is False
+
+
 def test_live_loop(monkeypatch, tmp_path):
     _make_dummy_strategy(tmp_path)
     cfg = _config(tmp_path)

--- a/tests/test_tx_engine.py
+++ b/tests/test_tx_engine.py
@@ -73,3 +73,14 @@ def test_kill_switch(tmp_path, monkeypatch):
     err_lines = err_log.read_text().splitlines()
     assert err_lines
     monkeypatch.delenv("KILL_SWITCH")
+
+
+def test_agent_gates_block(tmp_path):
+    web3 = DummyWeb3()
+    nm = NonceManager(web3, cache_file=str(tmp_path / "nonce.json"))
+    builder = TransactionBuilder(web3, nm, log_path=tmp_path / "log.json")
+    from agents.agent_registry import set_value
+    set_value("paused", True)
+    with pytest.raises(RuntimeError):
+        builder.send_transaction(HexBytes(b"\x01"), "0xabc")
+    set_value("paused", False)


### PR DESCRIPTION
## Summary
- add DRPAgent and gatekeeper modules
- enforce gating in orchestrator, TransactionBuilder, and promote module
- add script and CI step to check agent gates
- integrate time import for strategies
- extend ops agent and orchestrator tests for adversarial scenarios
- add gatekeeper unit tests

## Testing
- `ruff check agents/drp_agent.py agents/gatekeeper.py agents/check_gates.py core/orchestrator.py ai/promote.py core/tx_engine/builder.py tests/test_gatekeeper.py tests/test_ops_agent.py tests/test_orchestrator.py tests/test_tx_engine.py strategies/cross_rollup_superbot/strategy.py strategies/l3_app_rollup_mev/strategy.py strategies/nft_liquidation/strategy.py strategies/rwa_settlement/strategy.py`
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'hexbytes')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: No module named 'hexbytes')*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: No module named 'core')*