### PR TITLE
Document env vars and CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,16 @@ OPENAI_API_KEY= # OpenAI API key for online audits and intent classification
 INTENT_CLASSIFIER_LIVE=0 # 1 to enable real AI intent classification, 0 fallback stub
 
 # -------------------------
+# Flashbots / SUAVE Relays
+# -------------------------
+FLASHBOTS_AUTH_KEY= # Private key used for Flashbots/SUAVE bundles
+FLASHBOTS_RPC_URL=https://relay.flashbots.net
+
+# -------------------------
 # Founder & Ops Controls
 # -------------------------
 FOUNDER_APPROVED=0 # Must be 1 to enable live trading and promotions
+KILL_SWITCH=0 # Toggle global kill switch (1 = halt all trading)
 KILL_SWITCH_FLAG_FILE=./flags/kill_switch.txt
 KILL_SWITCH_LOG_FILE=./logs/kill_log.json
 CAPITAL_LOCK_ENABLED=true
@@ -45,6 +52,10 @@ METRICS_TOKEN= # Optional Bearer token for Prometheus metrics auth
 MUTATION_ID=dev # Tag for current mutation cycle
 TRACE_ID= # Unique approval trace ID
 DRP_ENC_KEY= # Optional key for DRP archive encryption
+EXPORT_DIR=export
+EXPORT_LOG_FILE=logs/export_state.json
+ROLLBACK_LOG_FILE=logs/rollback.log
+ERROR_LOG_FILE=logs/errors.log
 
 # -------------------------
 # Alerting & Notifications
@@ -84,6 +95,7 @@ STARTING_CAPITAL=2000.0
 GAS_LIMIT=3500000
 SLIPPAGE_BPS=50   # 0.5% slippage
 TRADE_AMOUNT_USD=100
+PRIORITY_FEE_GWEI=2  # default EIP-1559 tip
 
 # -------------------------
 # Optional / Future Proof

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,18 @@ strat = Strategy(..., capital_lock=lock)
 - On failure, `_bundle_and_send` falls back to `TransactionBuilder.send_transaction`.
 - Bundle latency is returned for metrics and log entry enrichment.
 
+## Agent CLI Reference
+
+| Command | Purpose |
+|---------|---------|
+| `python ai/promote.py` | Promote tested strategies into the active set. Requires `FOUNDER_APPROVED=1` and `TRACE_ID`. |
+| `python scripts/batch_ops.py promote <strat>` | Batch promote one or more strategies. |
+| `python scripts/batch_ops.py pause <strat>` | Move a live strategy to the paused directory. |
+| `python scripts/batch_ops.py rollback <strat>` | Restore a strategy from audit logs. |
+| `bash scripts/kill_switch.sh` | Toggle the global kill switch. |
+| `bash scripts/export_state.sh` | Export logs and state into `$EXPORT_DIR`. |
+| `bash scripts/rollback.sh --archive=<file>` | Restore from a DRP archive. |
+
 ---
 
 ## CODE QUALITY POLICIES

--- a/README.md
+++ b/README.md
@@ -152,12 +152,15 @@ MEV-OG reads settings from a `.env` file and `config.yaml`. Use
 ```
 OPENAI_API_KEY=<your-openai-key>          # Enables online audits
 FOUNDER_APPROVED=0                        # 1 allows promotion
+KILL_SWITCH=0                             # 1 halts all trading
 RPC_ETHEREUM_URL=<https://mainnet.ethereum.org>
 RPC_ARBITRUM_URL=<https://arbitrum.rpc>
 RPC_OPTIMISM_URL=<https://optimism.rpc>
-KILL_SWITCH_PATH=/tmp/mev_kill            # File trigger for halt
+KILL_SWITCH_FLAG_FILE=./flags/kill_switch.txt  # File trigger for halt
 METRICS_PORT=9102                         # Prometheus server port
 METRICS_TOKEN=<optional-token>            # Require auth header if set
+FLASHBOTS_AUTH_KEY=<hex-private-key>      # Required for bundle submission
+FLASHBOTS_RPC_URL=https://relay.flashbots.net
 ```
 
 Additional strategy values:
@@ -194,6 +197,7 @@ the values used in tests and the simulation harness:
 | `INTENT_FEED_URL` | `http://localhost:9000` | L3 intent feed |
 | `KILL_SWITCH_FLAG_FILE` | `./flags/kill_switch.txt` | Kill switch trigger file |
 | `KILL_SWITCH_LOG_FILE` | `/logs/kill_log.json` | Kill switch audit log |
+| `KILL_SWITCH` | `0` | Set to 1 to halt all trading |
 | `L3_APP_EXECUTOR` | `0x000...` | Executor for l3_app_rollup_mev |
 | `L3_APP_ROLLUP_LOG` | `logs/l3_app_rollup_mev.json` | l3_app_rollup_mev log |
 | `L3_APP_STATE_POST` | `state/l3_app_post.json` | Post DRP snapshot |
@@ -247,6 +251,12 @@ the values used in tests and the simulation harness:
 | `ORCH_LOGS_DIR` | `logs` | Directory for orchestrator logs |
 | `ORCH_MODE` | `dry-run` | Default run mode |
 | `WALLET_OPS_LOG` | `logs/wallet_ops.log` | Wallet operations audit log |
+| `EXPORT_DIR` | `export` | DRP export directory |
+| `EXPORT_LOG_FILE` | `logs/export_state.json` | DRP export audit log |
+| `ROLLBACK_LOG_FILE` | `logs/rollback.log` | Rollback audit log |
+| `FLASHBOTS_AUTH_KEY` | `<none>` | Private key for Flashbots bundles |
+| `FLASHBOTS_RPC_URL` | `https://relay.flashbots.net` | Flashbots/SUAVE relay |
+| `PRIORITY_FEE_GWEI` | `2` | Default EIP-1559 priority fee |
 
 ### cross_domain_arb Runbook
 


### PR DESCRIPTION
## Summary
- document new env vars for kill switch, DRP logs and Flashbots
- add priority fee and export paths to `.env.example`
- update README env var table with missing entries
- add Agent CLI reference to `AGENTS.md`

## Testing
- `pytest -v` *(fails: No module named 'hexbytes')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: No module named 'hexbytes')*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/export_state.json` *(fails: No module named 'core')*