### PR TITLE
Fix absolute log paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ the values used in tests and the simulation harness:
 | `FOUNDER_APPROVED` | `0` | 1 allows promote to production |
 | `INTENT_FEED_URL` | `http://localhost:9000` | L3 intent feed |
 | `KILL_SWITCH_FLAG_FILE` | `./flags/kill_switch.txt` | Kill switch trigger file |
-| `KILL_SWITCH_LOG_FILE` | `/logs/kill_log.json` | Kill switch audit log |
+| `KILL_SWITCH_LOG_FILE` | `logs/kill_log.json` | Kill switch audit log |
 | `KILL_SWITCH` | `0` | Set to 1 to halt all trading |
 | `L3_APP_EXECUTOR` | `0x000...` | Executor for l3_app_rollup_mev |
 | `L3_APP_ROLLUP_LOG` | `logs/l3_app_rollup_mev.json` | l3_app_rollup_mev log |

--- a/core/tx_engine/kill_switch.py
+++ b/core/tx_engine/kill_switch.py
@@ -19,7 +19,7 @@ def _flag_file() -> Path:
 def _log_file() -> Path:
     """Return path to the kill switch log file."""
 
-    return Path(os.getenv("KILL_SWITCH_LOG_FILE", "/logs/kill_log.json"))
+    return Path(os.getenv("KILL_SWITCH_LOG_FILE", "logs/kill_log.json"))
 
 
 LOG = StructuredLogger("kill_switch", log_file=str(_log_file()))

--- a/scripts/kill_switch.sh
+++ b/scripts/kill_switch.sh
@@ -2,7 +2,7 @@
 
 # Manual kill switch trigger script
 # Purpose: allow operators or DRP to enable/disable the system kill switch.
-# Logs all actions to /logs/kill_log.json in JSON format for audit.
+# Logs all actions to logs/kill_log.json in JSON format for audit.
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ done
 
 ENV_FILE="${ENV_FILE:-.env}"
 FLAG_FILE="${KILL_SWITCH_FLAG_FILE:-./flags/kill_switch.txt}"
-LOG_FILE="${KILL_SWITCH_LOG_FILE:-/logs/kill_log.json}"
+LOG_FILE="${KILL_SWITCH_LOG_FILE:-logs/kill_log.json}"
 USER_NAME="$(whoami 2>/dev/null || echo unknown)"
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 TRACE_ID="${TRACE_ID:-}"


### PR DESCRIPTION
## Summary
- ensure kill switch paths default to `logs/` not `/logs/`
- document relative path in README

## Testing
- `pytest -v` *(fails: No module named 'hexbytes')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: web3 required for fork simulation)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json`
