### PR TITLE
Add LLM-driven mutation flow

### DIFF
--- a/core/secret_manager.py
+++ b/core/secret_manager.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_secret(name: str) -> str:
+    """Return secret ``name`` from environment or file path.
+
+    The function first checks ``${name}_FILE`` for a file containing the
+    secret. If found, the file's contents are returned. Otherwise the
+    environment variable ``name`` is used. Raises ``RuntimeError`` if the
+    secret is not found.
+    """
+    file_var = f"{name}_FILE"
+    path = os.getenv(file_var)
+    if path:
+        p = Path(path)
+        if p.exists():
+            return p.read_text().strip()
+    val = os.getenv(name)
+    if val:
+        return val
+    raise RuntimeError(f"secret {name} not found")

--- a/tests/test_mutator_llm.py
+++ b/tests/test_mutator_llm.py
@@ -1,0 +1,38 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from ai.mutator.mutator import Mutator
+
+
+class FakeMsg:
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeResp:
+    def __init__(self, text):
+        self.choices = [type("C", (), {"message": FakeMsg(text)})]
+
+
+class FakeChat:
+    @staticmethod
+    def create(model, messages):
+        return FakeResp('{"params": {"threshold": 0.1}}')
+
+
+def test_mutator_llm(monkeypatch, tmp_path):
+    strat_dir = tmp_path / "strategies" / "foo"
+    strat_dir.mkdir(parents=True)
+    (strat_dir / "strategy.py").write_text("class Foo:\n    pass\n")
+
+    monkeypatch.setitem(
+        sys.modules, "openai", type("O", (), {"ChatCompletion": FakeChat})
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    metrics = {"foo": {"pnl": 1}}
+    mut = Mutator(metrics, live=True, strategy_root=str(tmp_path / "strategies"))
+    out = mut.mutate("foo", {"threshold": 0.05})
+    assert out == {"threshold": 0.1}


### PR DESCRIPTION
## Summary
- extend `Mutator` with LLM mutation logic and dry-run mode
- centralize secret loading via `core.secret_manager.get_secret`
- test LLM mutation path

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: eth_account, etc.)*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: hexbytes)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: core)*