### PR TITLE
Fix lint issues in tests

### DIFF
--- a/tests/test_capital_lock.py
+++ b/tests/test_capital_lock.py
@@ -24,7 +24,7 @@ def test_lock_and_unlock(monkeypatch, tmp_path):
     log_path = tmp_path / "lock.json"
     if not log_path.exists():
         pytest.skip("lock.json not created")
-    entries = [json.loads(l) for l in log_path.read_text().splitlines()]
+    entries = [json.loads(line) for line in log_path.read_text().splitlines()]
     assert entries[-1]["event"] == "unlock"
     assert entries[-1]["trace_id"] == "t123"
 
@@ -39,7 +39,7 @@ def test_unlock_requires_founder(monkeypatch, tmp_path):
     log_path = tmp_path / "lock.json"
     if not log_path.exists():
         pytest.skip("lock.json not created")
-    entries = [json.loads(l) for l in log_path.read_text().splitlines()]
+    entries = [json.loads(line) for line in log_path.read_text().splitlines()]
     assert entries[-1]["event"] == "unlock_rejected"
     assert entries[-1]["trace_id"] == "nope"
 

--- a/tests/test_mutator_main.py
+++ b/tests/test_mutator_main.py
@@ -81,6 +81,6 @@ def test_mutation_cycle_requires_founder(monkeypatch, tmp_path):
     runner.run_cycle()
 
     assert not promos
-    entries = [json.loads(l) for l in (logs / "errors.log").read_text().splitlines()]
+    entries = [json.loads(line) for line in (logs / "errors.log").read_text().splitlines()]
     assert entries[-1]["event"] == "promote_gate"
     assert entries[-1]["trace_id"] == "block"

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -93,7 +93,10 @@ def test_reset_increment_race(tmp_path):
 
     t1 = threading.Thread(target=do_get)
     t2 = threading.Thread(target=do_reset)
-    t1.start(); t2.start(); t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     final = nm.get_nonce("0xabc")
     assert final >= 5

--- a/tests/test_tx_engine.py
+++ b/tests/test_tx_engine.py
@@ -97,7 +97,10 @@ def test_cross_agent_order_flow(tmp_path):
 
     t1 = threading.Thread(target=send, args=(b1, HexBytes(b"\x01")))
     t2 = threading.Thread(target=send, args=(b2, HexBytes(b"\x02")))
-    t1.start(); t2.start(); t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     # nonces should be sequential across builders
     assert nm.get_nonce("0xabc") == 2


### PR DESCRIPTION
## Notes
- `foundry test`, `pytest`, `ai/audit_agent.py`, and `scripts/simulate_fork.sh` failed or couldn't run due to missing dependencies. `scripts/export_state.sh --dry-run` succeeded.

## Summary
- replace ambiguous `l` variable with `line` in capital lock and mutator tests
- split thread start/join calls onto separate lines in nonce manager and tx engine tests

## Testing
- `ruff check .`
- `foundry test` *(fails: command not found)*
- `pytest -q` *(fails: 15 failed, 73 passed, 4 skipped)*
- `scripts/simulate_fork.sh --target=strategies/example` *(fails: unknown target)*
- `scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/example.json` *(fails: ModuleNotFoundError)*