### PR TITLE
Fix Ruff lint error

### DIFF
--- a/ai/mutator/score.py
+++ b/ai/mutator/score.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from statistics import mean, stdev
 from typing import Any, Dict, List
 import hashlib
 


### PR DESCRIPTION
## Notes
- `pytest` fails because the repository requires dependencies like `eth_account` and gating artifacts unavailable in the Codex environment.
- `foundry` is not installed, so `foundry test` couldn't run.
- Fork simulation failed with `Unknown target: strategies/dummy`.
- `scripts/export_state.sh --dry-run` executed successfully.
- `ai/audit_agent.py --mode=offline` failed due to missing module path.

## Summary
- removed unused imports `mean` and `stdev` from `ai/mutator/score.py`

All Ruff checks now pass.
