### PR TITLE
Fix gate and nonce tests

### DIFF
--- a/tests/test_cross_domain_arb.py
+++ b/tests/test_cross_domain_arb.py
@@ -128,7 +128,13 @@ def test_should_trade_now_high_gas(monkeypatch):
             "0xdeadbeef00000000000000000000000000000000", "ethereum"
         )
     }
-    strat = CrossDomainArb(pools, {"stealth_mode": True}, threshold=0.01, capital_lock=CapitalLock(1000, 1e9, 0))
+    strat = CrossDomainArb(
+        pools,
+        {},
+        threshold=0.01,
+        capital_lock=CapitalLock(1000, 1e9, 0),
+        edges_enabled={"stealth_mode": True},
+    )
     strat.feed = DummyFeed({"ethereum": 100})
     strat.tx_builder.web3 = strat.feed.web3s["ethereum"]
     strat.nonce_manager.web3 = strat.feed.web3s["ethereum"]


### PR DESCRIPTION
## Summary
- ensure NonceManager uses a reentrant lock for thread safety
- add `nonce_state` helper and expose peek
- patch tx_engine tests so agent gates default to open and check kill log exists
- update cross-domain arb high-gas test setup
- add atomic nonce race test

## Testing
- `pytest tests/test_tx_engine.py tests/test_nonce_manager.py::test_atomic_increment_race -q`
- `scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/tx_engine.json` *(fails: ModuleNotFoundError)*
- `foundry test` *(fails: command not found)*