### PR TITLE
Add expanded chaos drill and metrics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   build:
@@ -35,6 +37,8 @@ jobs:
         run: bash scripts/export_state.sh --dry-run
       - name: Offline audit
         run: python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+      - name: Chaos drill
+        run: python infra/sim_harness/chaos_drill.py
       - name: Tag canary
         run: |
           TAG="canary-${{ github.sha }}-$(date +%Y%m%d)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,15 @@ Every PR or batch/module must pass:
 * Mutation cycle:
   `python ai/mutator/main.py --logs-dir logs`
 
+### chaos_drill
+
+* Run harness:
+  `python infra/sim_harness/chaos_drill.py`
+* Validate:
+  `pytest tests/test_chaos_drill.py`
+* Results are written to `logs/chaos_drill.json` with per-adapter failure counts in `logs/drill_metrics.json`.
+  CI fails if any secrets/PII are detected in logs or DRP exports.
+
 ### OpsAgent & CapitalLock Runbook
 
 * Start OpsAgent:

--- a/README.md
+++ b/README.md
@@ -459,6 +459,23 @@ bash scripts/kill_switch.sh --clean
 Environment variables `KILL_SWITCH_FLAG_FILE` and `KILL_SWITCH_LOG_FILE` control
 the flag and log paths.
 
+
+## Chaos/DR Drill
+
+Run the automated chaos/disaster recovery drill harness:
+
+```bash
+python infra/sim_harness/chaos_drill.py
+```
+
+This triggers the kill switch, pauses capital via OpsAgent, simulates a lost agent, and forces failure across every supported adapter (DEX, bridge, CEX, flashloan, intent, sequencer and node). After each event the drill exports state with `scripts/export_state.sh`, restores it with `scripts/rollback.sh`, and scans all logs/archives for secrets or PII. Any secret causes an immediate failure. Export archives are stored in `export/`, drill logs in `logs/chaos_drill.json`, and per-module failure counts in `logs/drill_metrics.json`.
+
+Validate locally with:
+
+```bash
+pytest tests/test_chaos_drill.py
+```
+
 ## OpsAgent & CapitalLock
 
 `agents/ops_agent.py` runs periodic health checks and pauses all strategies if

--- a/ai/mutator/score.py
+++ b/ai/mutator/score.py
@@ -2,6 +2,7 @@
 
 Module purpose and system role:
     - Evaluate performance metrics for each strategy and produce a ranking.
+    - Penalize chaos drill failures and DR events so unstable modules are pruned.
     - Emit scores to JSON and structured logs for later mutation.
 
 Integration points and dependencies:
@@ -17,7 +18,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from statistics import mean, stdev
+
 from typing import Any, Dict, List
 import hashlib
 
@@ -58,8 +59,18 @@ def score_strategies(
         drawdown = float(data.get("drawdown", 0.0))
         win_rate = float(data.get("win_rate", 0.0))
         failures = int(data.get("failures", 0))
+        chaos = int(data.get("chaos_failures", 0))
+        dr_triggers = int(data.get("dr_triggers", 0))
 
-        score = pnl + sharpe * 100 - drawdown * 50 + win_rate * 10 - failures * 20
+        score = (
+            pnl
+            + sharpe * 100
+            - drawdown * 50
+            + win_rate * 10
+            - failures * 20
+            - chaos * 10
+            - dr_triggers * 5
+        )
 
         vh = _version_hash(sid, data)
 
@@ -74,6 +85,8 @@ def score_strategies(
                 "drawdown": drawdown,
                 "win_rate": win_rate,
                 "failures": failures,
+                "chaos_failures": chaos,
+                "dr_triggers": dr_triggers,
             }
         )
 

--- a/infra/sim_harness/chaos_drill.py
+++ b/infra/sim_harness/chaos_drill.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Automated chaos/disaster recovery drill harness."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tarfile
+from pathlib import Path
+
+from agents.ops_agent import OpsAgent
+from core.logger import StructuredLogger
+from core.tx_engine.kill_switch import flag_file, init_kill_switch
+from adapters import (
+    BridgeAdapter,
+    CEXAdapter,
+    DEXAdapter,
+    FlashloanAdapter,
+)
+from ai.intent_ghost import ghost_intent
+from core.node_selector import NodeSelector
+
+EXPORT_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "export_state.sh"
+ROLLBACK_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "rollback.sh"
+
+LOGGER = StructuredLogger("chaos_drill")
+DRILL_METRICS_FILE = Path(os.getenv("CHAOS_METRICS", "logs/drill_metrics.json"))
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(api[_-]?key|secret|private[_-]?key)"),
+    re.compile(r"0x[a-fA-F0-9]{64}"),
+]
+
+
+def _run(cmd: list[str], env: dict[str, str]) -> None:
+    result = subprocess.run(cmd, text=True, env=env, capture_output=True)
+    LOGGER.log(
+        "cmd_run",
+        risk_level="low",
+        cmd=" ".join(cmd),
+        returncode=result.returncode,
+    )
+    if result.returncode != 0:
+        LOGGER.log(
+            "cmd_fail",
+            risk_level="high",
+            cmd=" ".join(cmd),
+            error=result.stderr,
+        )
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+
+
+def _export_and_restore(env: dict[str, str]) -> None:
+    LOGGER.log("export", risk_level="low")
+    _run(["bash", str(EXPORT_SCRIPT)], env)
+    LOGGER.log("restore", risk_level="low")
+    _run(["bash", str(ROLLBACK_SCRIPT)], env)
+    _check_for_secrets(env)
+
+
+def _update_metrics(module: str) -> None:
+    metrics: dict[str, dict[str, int]] = {}
+    if DRILL_METRICS_FILE.exists():
+        try:
+            metrics = json.loads(DRILL_METRICS_FILE.read_text())
+        except Exception:
+            metrics = {}
+    metrics.setdefault(module, {"failures": 0})
+    metrics[module]["failures"] += 1
+    DRILL_METRICS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DRILL_METRICS_FILE.write_text(json.dumps(metrics, indent=2))
+
+
+def _scan_file(path: Path) -> None:
+    try:
+        data = path.read_text(errors="ignore")
+    except Exception:
+        return
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(data):
+            raise RuntimeError(f"Secret detected in {path}")
+
+
+def _check_for_secrets(env: dict[str, str]) -> None:
+    export_dir = Path(env.get("EXPORT_DIR", "export"))
+    for p in export_dir.rglob("*"):
+        if p.is_file():
+            if p.suffixes[-2:] == [".tar", ".gz"] or p.suffix == ".tar.gz":
+                with tarfile.open(p) as tar:
+                    for m in tar.getmembers():
+                        if m.isfile():
+                            f = tar.extractfile(m)
+                            if f:
+                                data = f.read().decode(errors="ignore")
+                                for pattern in SECRET_PATTERNS:
+                                    if pattern.search(data):
+                                        raise RuntimeError(f"Secret detected in archive {p}::{m.name}")
+            else:
+                _scan_file(p)
+    _scan_file(LOGGER.path)
+
+
+def _drill_kill_switch(env: dict[str, str]) -> None:
+    init_kill_switch()
+    ff = flag_file()
+    ff.parent.mkdir(parents=True, exist_ok=True)
+    ff.write_text("1")
+    LOGGER.log("kill_switch_forced", risk_level="high")
+    _export_and_restore(env)
+
+
+def _drill_lost_agent(env: dict[str, str]) -> None:
+    ops = OpsAgent({})
+    ops.auto_pause(reason="lost_agent")
+    LOGGER.log("lost_agent", risk_level="high")
+    _export_and_restore(env)
+
+
+def _drill_adapter_fail(env: dict[str, str]) -> None:
+    try:
+        adapter = DEXAdapter("http://127.0.0.1:1")
+        adapter.get_quote("ETH", "USDC", 1)
+    except Exception:
+        LOGGER.log("adapter_fail", risk_level="high")
+        _update_metrics("dex_adapter")
+    _export_and_restore(env)
+
+
+def _drill_bridge_fail(env: dict[str, str]) -> None:
+    try:
+        adapter = BridgeAdapter("http://127.0.0.1:1")
+        adapter.bridge("eth", "arb", "ETH", 1)
+    except Exception:
+        LOGGER.log("bridge_fail", risk_level="high")
+        _update_metrics("bridge_adapter")
+    _export_and_restore(env)
+
+
+def _drill_cex_fail(env: dict[str, str]) -> None:
+    try:
+        adapter = CEXAdapter("http://127.0.0.1:1", "bad")
+        adapter.place_order("buy", 1, 1)
+    except Exception:
+        LOGGER.log("cex_fail", risk_level="high")
+        _update_metrics("cex_adapter")
+    _export_and_restore(env)
+
+
+def _drill_flashloan_fail(env: dict[str, str]) -> None:
+    try:
+        adapter = FlashloanAdapter("http://127.0.0.1:1")
+        adapter.trigger("ETH", 1)
+    except Exception:
+        LOGGER.log("flashloan_fail", risk_level="high")
+        _update_metrics("flashloan_adapter")
+    _export_and_restore(env)
+
+
+def _drill_intent_fail(env: dict[str, str]) -> None:
+    try:
+        ghost_intent("http://127.0.0.1:1", {"intent_id": "x"})
+    except Exception:
+        LOGGER.log("intent_fail", risk_level="high")
+        _update_metrics("intent")
+    _export_and_restore(env)
+
+
+def _drill_node_fail(env: dict[str, str]) -> None:
+    try:
+        selector = NodeSelector({})
+        selector.best()
+    except Exception:
+        LOGGER.log("node_fail", risk_level="high")
+        _update_metrics("node")
+    _export_and_restore(env)
+
+
+def _drill_sequencer_fail(env: dict[str, str]) -> None:
+    try:
+        from strategies.l3_sequencer_mev.strategy import L3SequencerMEV
+
+        strat = L3SequencerMEV({})
+        strat._bundle_and_send("test")
+    except Exception:
+        LOGGER.log("sequencer_fail", risk_level="high")
+        _update_metrics("sequencer")
+    _export_and_restore(env)
+
+
+def run_drill() -> None:
+    env = os.environ.copy()
+    _drill_kill_switch(env)
+    _drill_lost_agent(env)
+    _drill_adapter_fail(env)
+    _drill_bridge_fail(env)
+    _drill_cex_fail(env)
+    _drill_flashloan_fail(env)
+    _drill_intent_fail(env)
+    _drill_node_fail(env)
+    _drill_sequencer_fail(env)
+
+
+if __name__ == "__main__":
+    run_drill()

--- a/tests/test_chaos_drill.py
+++ b/tests/test_chaos_drill.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import json
+
+SCRIPT = Path(__file__).resolve().parents[1] / "infra" / "sim_harness" / "chaos_drill.py"
+
+
+def test_chaos_drill(tmp_path):
+    # prepare minimal state
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "x.log").write_text("log")
+    (tmp_path / "state").mkdir()
+    (tmp_path / "state" / "x.txt").write_text("state")
+    (tmp_path / "active").mkdir()
+    (tmp_path / "active" / "a.txt").write_text("active")
+    (tmp_path / "keys").mkdir()
+    (tmp_path / "keys" / "k.txt").write_text("k")
+
+    env = os.environ.copy()
+    env.update({
+        "EXPORT_DIR": str(tmp_path / "export"),
+        "EXPORT_LOG_FILE": str(tmp_path / "export_log.json"),
+        "ROLLBACK_LOG_FILE": str(tmp_path / "rollback.log"),
+        "ERROR_LOG_FILE": str(tmp_path / "errors.log"),
+        "KILL_SWITCH_LOG_FILE": str(tmp_path / "kill_log.json"),
+        "KILL_SWITCH_FLAG_FILE": str(tmp_path / "flag.txt"),
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+        "PWD": str(tmp_path),
+    })
+    subprocess.run([sys.executable, str(SCRIPT)], check=True, env=env, text=True)
+
+    exports = list((tmp_path / "export").glob("drp_export_*.tar.gz"))
+    assert len(exports) >= 9
+    assert (tmp_path / "rollback.log").exists()
+    with open(tmp_path / "export_log.json") as fh:
+        lines = [json.loads(line) for line in fh]
+    assert any(e.get("event") == "export" for e in lines)
+
+    metrics = json.loads(Path(tmp_path / "logs" / "drill_metrics.json").read_text())
+    assert metrics["dex_adapter"]["failures"] >= 1

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -16,6 +16,8 @@ def test_score_and_prune(tmp_path):
             "drawdown": 0.1,
             "win_rate": 0.75,
             "failures": 0,
+            "chaos_failures": 0,
+            "dr_triggers": 0,
         },
         "stratB": {
             "realized_pnl": -5,
@@ -23,6 +25,8 @@ def test_score_and_prune(tmp_path):
             "drawdown": 0.5,
             "win_rate": 0.2,
             "failures": 2,
+            "chaos_failures": 1,
+            "dr_triggers": 1,
         },
     }
     scores = score_strategies(metrics, output_path=str(tmp_path / "scores.json"), top_n=1)


### PR DESCRIPTION
## Summary
- expand chaos drill to cover all adapters and log exports
- scan DRP archives for secrets and update metrics
- tie drill failures to strategy score penalties
- document enhanced drill runbook

## Testing
- `ruff check infra/sim_harness/chaos_drill.py tests/test_chaos_drill.py ai/mutator/score.py tests/test_mutator.py`
- `pytest -v` *(fails: missing deps)*
- `foundry test` *(command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`
