### PR TITLE
Implement live strategy scoreboard and pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,13 @@ strat = Strategy(..., capital_lock=lock)
 - Adjust `PRIORITY_FEE_GWEI` to set the priority fee for bundles.
 - On failure, `_bundle_and_send` falls back to `TransactionBuilder.send_transaction`.
 - Bundle latency is returned for metrics and log entry enrichment.
+### Strategy Review & Pruning
+
+- Run `python -m core.strategy_scoreboard` or call `StrategyScoreboard.prune_and_score()` after each trading loop.
+- Review `logs/scoreboard.json` for risk-adjusted scores with external alpha signals.
+- Set `FOUNDER_APPROVED=1` to enable auto-pruning and live capital changes. Alerts are dispatched via `OpsAgent.notify`.
+- Every prune/promote/mutation event is recorded in `logs/mutation_log.json` using the current `TRACE_ID`.
+
 
 ## Agent CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -539,6 +539,10 @@ Example usage:
 ```bash
 python scripts/batch_ops.py promote cross_rollup_superbot --source-dir staging --dest-dir active
 ```
+## Strategy Review & Pruning
+
+Use `core.strategy_scoreboard.StrategyScoreboard` to benchmark live strategies against real-time DEX/CEX gaps, whale alerts, and news sentiment. Call `scoreboard.prune_and_score()` after each trading loop to score performance and auto-prune if `FOUNDER_APPROVED=1`. Rankings are written to `logs/scoreboard.json` and all prune events are appended to `logs/mutation_log.json` with alerts sent via the Ops agent.
+
 
 ## Wallet Operations
 

--- a/core/strategy_scoreboard.py
+++ b/core/strategy_scoreboard.py
@@ -1,0 +1,181 @@
+"""Advanced live strategy benchmarking and pruning."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from typing import Any, Callable, Dict, List
+
+from core.logger import StructuredLogger
+from ai.mutator import score_strategies, prune_strategies
+from ai.mutation_log import log_mutation
+
+
+class SignalProvider:
+    """Base class for external alpha signal providers."""
+
+    def fetch(self) -> Dict[str, float]:  # pragma: no cover - interface
+        return {}
+
+
+class ExternalSignalFetcher:
+    """Aggregate multiple real-time signal providers."""
+
+    def __init__(self, path: str | None = None, providers: List[SignalProvider] | None = None) -> None:
+        self.path = path or os.getenv("EXTERNAL_ALPHA_PATH", "data/external_signals.json")
+        self.providers = providers or []
+
+    # ------------------------------------------------------------------
+    def _file_signals(self) -> Dict[str, float]:
+        if not os.path.exists(self.path):
+            return {}
+        try:
+            with open(self.path) as fh:
+                data = json.load(fh)
+                if isinstance(data, dict):
+                    return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+                return {}
+        except Exception:
+            return {}
+
+    # ------------------------------------------------------------------
+    def fetch(self) -> Dict[str, float]:
+        signals: Dict[str, float] = self._file_signals()
+        for prov in list(self.providers):
+            try:
+                signals.update(prov.fetch())
+            except Exception:
+                continue
+        return signals
+
+
+class AlphaDecayModel:
+    """Detect alpha decay and regime shifts via score trends."""
+
+    def __init__(self, window: int = 5) -> None:
+        self.history: Dict[str, List[float]] = defaultdict(list)
+        self.window = window
+
+    # ------------------------------------------------------------------
+    def score(self, sid: str, metrics: Dict[str, float], signals: Dict[str, float]) -> float:
+        base = (
+            metrics.get("realized_pnl", 0.0)
+            + metrics.get("edge_vs_market", 0.0) * 2
+            + metrics.get("win_rate", 0.0) * 10
+            - metrics.get("drawdown", 0.0) * 50
+            - metrics.get("failures", 0.0) * 20
+            + signals.get("whale_flow", 0.0) * 2
+            + signals.get("news_sentiment", 0.0) * 5
+        )
+        hist = self.history[sid]
+        hist.append(base)
+        if len(hist) > self.window:
+            hist.pop(0)
+        slope = 0.0
+        n = len(hist)
+        if n > 1:
+            x = list(range(n))
+            sum_x = sum(x)
+            sum_y = sum(hist)
+            sum_xy = sum(x[i] * hist[i] for i in range(n))
+            sum_xx = sum(i * i for i in x)
+            denom = n * sum_xx - sum_x * sum_x
+            if denom:
+                slope = (n * sum_xy - sum_x * sum_y) / denom
+        return base + slope * 10
+
+    # ------------------------------------------------------------------
+    def decayed(self, sid: str) -> bool:
+        hist = self.history.get(sid, [])
+        if len(hist) < self.window:
+            return False
+        n = len(hist)
+        x = list(range(n))
+        sum_x = sum(x)
+        sum_y = sum(hist)
+        sum_xy = sum(x[i] * hist[i] for i in range(n))
+        sum_xx = sum(i * i for i in x)
+        denom = n * sum_xx - sum_x * sum_x
+        slope = (n * sum_xy - sum_x * sum_y) / denom if denom else 0.0
+        return slope < -0.1
+
+
+class StrategyScoreboard:
+    """Collect metrics, rank strategies and prune underperformers."""
+
+    def __init__(self, orchestrator: Any, signal_fetcher: ExternalSignalFetcher | None = None, model: AlphaDecayModel | None = None) -> None:
+        self.orchestrator = orchestrator
+        self.signal_fetcher = signal_fetcher or ExternalSignalFetcher()
+        self.model = model or AlphaDecayModel()
+        self.logger = StructuredLogger("strategy_scoreboard")
+
+    # --------------------------------------------------------------
+    def collect_metrics(self) -> Dict[str, Dict[str, float]]:
+        """Return live metrics enriched with market signals."""
+        ext = self.signal_fetcher.fetch()
+        market_pnl = float(ext.get("market_pnl", 0.0))
+        metrics: Dict[str, Dict[str, float]] = {}
+        strategies = getattr(self.orchestrator, "strategies", {})
+        for sid, strat in strategies.items():
+            trades: List[float] = getattr(getattr(strat, "capital_lock", strat), "trades", [])
+            pnl = float(sum(trades))
+            losses = sum(1 for t in trades if t < 0)
+            risk = losses / float(len(trades) or 1)
+            edge = pnl - market_pnl
+            metrics[sid] = {
+                "realized_pnl": pnl,
+                "edge_vs_market": edge,
+                "win_rate": 1 - risk,
+                "drawdown": risk,
+                "failures": 0,
+            }
+        return metrics
+
+    # --------------------------------------------------------------
+    def prune_and_score(self) -> Dict[str, Any]:
+        """Score strategies and auto-prune underperformers."""
+        metrics = self.collect_metrics()
+        signals = self.signal_fetcher.fetch()
+        scores = {}
+        ranking: List[Dict[str, Any]] = []
+        for sid, data in metrics.items():
+            score = self.model.score(sid, data, signals)
+            scores[sid] = score
+            ranking.append({"strategy": sid, "score": score})
+        ranking.sort(key=lambda x: x["score"], reverse=True)
+        json_path = "logs/scoreboard.json"
+        os.makedirs(os.path.dirname(json_path), exist_ok=True)
+        with open(json_path, "w") as fh:
+            json.dump(ranking, fh, indent=2)
+        flagged = prune_strategies(metrics)
+        for sid in list(scores):
+            if self.model.decayed(sid):
+                flagged.append(sid)
+        flagged = list(dict.fromkeys(flagged))
+        pruned: List[str] = []
+        for sid in flagged:
+            self.logger.log("prune_strategy", strategy_id=sid, risk_level="medium")
+            log_mutation("auto_prune", strategy_id=sid)
+            if os.getenv("FOUNDER_APPROVED") == "1":
+                self.orchestrator.strategies.pop(sid, None)
+                pruned.append(sid)
+                if hasattr(self.orchestrator, "ops_agent"):
+                    self.orchestrator.ops_agent.notify(f"pruned {sid}")
+        score_strategies(metrics, output_path=json_path)
+        return {"scores": ranking, "pruned": pruned}
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    import argparse
+    from core.orchestrator import StrategyOrchestrator
+
+    parser = argparse.ArgumentParser(description="Run strategy scoreboard")
+    parser.add_argument("--config", default="config.yaml", help="Orchestrator config")
+    args = parser.parse_args()
+
+    orch = StrategyOrchestrator(args.config)
+    board = StrategyScoreboard(orch)
+    result = board.prune_and_score()
+    print(json.dumps(result, indent=2))
+

--- a/tests/test_strategy_scoreboard.py
+++ b/tests/test_strategy_scoreboard.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import os
+import sys
+
+import pytest
+pytest.importorskip("hexbytes")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from core.strategy_scoreboard import StrategyScoreboard, ExternalSignalFetcher
+from agents.capital_lock import CapitalLock
+from strategies.cross_domain_arb import PoolConfig, CrossDomainArb
+
+
+class DummyOps:
+    def __init__(self):
+        self.notifications = []
+
+    def notify(self, msg: str) -> None:
+        self.notifications.append(msg)
+
+
+class DummyOrch:
+    def __init__(self):
+        pools = {
+            "eth": PoolConfig("0xdeadbeef00000000000000000000000000000000", "ethereum")
+        }
+        strat = CrossDomainArb(pools, {}, capital_lock=CapitalLock(1000, 1e9, 0))
+        strat.capital_lock.trades = [1.0, -0.5, 0.2]
+        self.strategies = {"dummy": strat}
+        self.ops_agent = DummyOps()
+
+    def status(self):
+        return {}
+
+
+def test_scoreboard_decay_prune(tmp_path, monkeypatch):
+    signals = tmp_path / "signals.json"
+    signals.write_text('{"market_pnl": 0.1, "news_sentiment": 0.1}')
+    fetcher = ExternalSignalFetcher(str(signals))
+    orch = DummyOrch()
+    sb = StrategyScoreboard(orch, fetcher)
+    sb.prune_and_score()  # initial run
+    assert "dummy" in orch.strategies
+    orch.strategies["dummy"].capital_lock.trades.extend([-1.0, -1.0, -1.0])
+    monkeypatch.setenv("FOUNDER_APPROVED", "1")
+    res = sb.prune_and_score()
+    assert "dummy" not in orch.strategies
+    assert "dummy" in res["pruned"]
+    assert orch.ops_agent.notifications
+
+
+def test_scoreboard_no_false_positive(tmp_path):
+    signals = tmp_path / "signals.json"
+    signals.write_text('{"market_pnl": 0.0}')
+    fetcher = ExternalSignalFetcher(str(signals))
+    orch = DummyOrch()
+    sb = StrategyScoreboard(orch, fetcher)
+    res = sb.prune_and_score()
+    assert res["pruned"] == []
+    assert Path("logs/scoreboard.json").exists()
+


### PR DESCRIPTION
## Summary
- expand StrategyScoreboard with signal providers and alpha-decay model
- auto prune underperformers when founder approved and alert ops
- document new scoreboard workflow in README and AGENTS
- add adversarial tests for decay pruning and false positives

## Testing
- `pytest -v` *(fails: flashbots/hexbytes missing)*
- `foundry test` *(command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: hexbytes)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: core)*