### PR TITLE
Implement adapter chaos hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,14 @@ Every PR or batch/module must pass:
 * Results are written to `logs/chaos_drill.json` with per-adapter failure counts in `logs/drill_metrics.json`.
   CI fails if any secrets/PII are detected in logs or DRP exports.
 
+### adapter_chaos
+
+* Run targeted adapter chaos tests:
+  `pytest tests/test_adapters_chaos.py`
+* Manual simulation:
+  `python tests/test_adapters_chaos.py --simulate bridge_downtime`
+* Expect `fallback_success` events in module logs and OpsAgent alerts for each failure.
+
 ### OpsAgent & CapitalLock Runbook
 
 * Start OpsAgent:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up down test simulate mutate export promote
+.PHONY: build up down test chaos simulate mutate export promote
 
 build:
 docker compose build
@@ -10,7 +10,10 @@ down:
 docker compose down
 
 test:
-pytest -v && foundry test
+    pytest -v && foundry test
+
+chaos:
+    pytest tests/test_adapters_chaos.py -v
 
 simulate:
 bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb

--- a/README.md
+++ b/README.md
@@ -483,6 +483,29 @@ Validate locally with:
 pytest tests/test_chaos_drill.py
 ```
 
+### Adapter Chaos Simulation
+
+Each adapter implements failure injection and fallback logic. Run targeted chaos tests with:
+
+```bash
+pytest tests/test_adapters_chaos.py
+```
+
+Manual simulation example:
+
+```bash
+python tests/test_adapters_chaos.py --simulate bridge_downtime
+```
+
+During a network outage the logs include entries like:
+
+```json
+{"event":"fallback_success","module":"dex_adapter","risk_level":"low"}
+```
+
+Metrics from the chaos run are written to `logs/drill_metrics.json` and OpsAgent
+dispatches alerts for each failure.
+
 ## OpsAgent & CapitalLock
 
 `agents/ops_agent.py` runs periodic health checks and pauses all strategies if

--- a/adapters/alpha_signals.py
+++ b/adapters/alpha_signals.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import threading
 import time
-from typing import Dict
+from typing import Dict, Optional
+
+from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
 from core.rate_limiter import RateLimiter
@@ -15,17 +17,48 @@ from core.strategy_scoreboard import SignalProvider
 class DuneAnalyticsAdapter(SignalProvider):
     """Fetch query results from Dune Analytics."""
 
-    def __init__(self, api_url: str, api_key: str, query_id: str, rate: float = 1.0) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        query_id: str,
+        rate: float = 1.0,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
         self.api_key = api_key
         self.query_id = query_id
         self.rate = RateLimiter(rate)
         self.logger = StructuredLogger("dune_adapter")
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
 
-    def fetch(self) -> Dict[str, float]:
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        self.logger.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"dune_adapter:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
+
+    def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
         self.rate.wait()
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"bad": float("nan")}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 429")
 
             resp = requests.get(
                 f"{self.api_url}/v1/query/{self.query_id}/results",
@@ -40,23 +73,67 @@ class DuneAnalyticsAdapter(SignalProvider):
             data = resp.json().get("result", {})
             return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
         except Exception as exc:  # pragma: no cover - network errors
-            self.logger.log("dune_fail", risk_level="medium", error=str(exc))
+            self._alert("dune_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.get(
+                        f"{self.alt_api_url}/v1/query/{self.query_id}/results",
+                        headers={"X-Dune-API-Key": self.api_key},
+                        timeout=5,
+                    )
+                    resp.raise_for_status()
+                    self.logger.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    data = resp.json().get("result", {})
+                    return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             return {}
 
 
 class WhaleAlertAdapter(SignalProvider):
     """Realtime whale transaction alerts."""
 
-    def __init__(self, api_url: str, api_key: str, rate: float = 0.5) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        rate: float = 0.5,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
         self.api_key = api_key
         self.rate = RateLimiter(rate)
         self.logger = StructuredLogger("whale_alert")
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
 
-    def fetch(self) -> Dict[str, float]:
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        self.logger.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"whale_alert:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
+
+    def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
         self.rate.wait()
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"whale_flow": float("nan")}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 429")
 
             resp = requests.get(
                 f"{self.api_url}/transactions", params={"api_key": self.api_key}, timeout=5
@@ -70,28 +147,64 @@ class WhaleAlertAdapter(SignalProvider):
             score = float(len(data))
             return {"whale_flow": score}
         except Exception as exc:  # pragma: no cover - network errors
-            self.logger.log("whale_fail", risk_level="medium", error=str(exc))
+            self._alert("whale_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.get(
+                        f"{self.alt_api_url}/transactions",
+                        params={"api_key": self.api_key},
+                        timeout=5,
+                    )
+                    resp.raise_for_status()
+                    self.logger.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    data = resp.json().get("transactions", [])
+                    score = float(len(data))
+                    return {"whale_flow": score}
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             return {}
 
 
 class CoinbaseWebSocketAdapter(SignalProvider):
     """Live Coinbase futures orderbook feed."""
 
-    def __init__(self, ws_url: str, product: str = "BTC-USD") -> None:
+    def __init__(
+        self,
+        ws_url: str,
+        product: str = "BTC-USD",
+        *,
+        alt_ws_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.ws_url = ws_url
+        self.alt_ws_url = alt_ws_url
         self.product = product
         self.logger = StructuredLogger("coinbase_ws")
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
         self.latest: Dict[str, float] = {}
         self._lock = threading.Lock()
         self._stop = False
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        self.logger.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"coinbase_ws:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            self._stop = True
+            raise RuntimeError("circuit breaker open")
+
     def _run(self) -> None:
         try:
             import websocket  # type: ignore
         except Exception as exc:  # pragma: no cover - missing dep
-            self.logger.log("ws_import_fail", risk_level="high", error=str(exc))
+            self._alert("ws_import_fail", exc)
             return
         while not self._stop:
             try:
@@ -106,7 +219,12 @@ class CoinbaseWebSocketAdapter(SignalProvider):
                         with self._lock:
                             self.latest["coinbase_price"] = float(data.get("price", 0.0))
             except Exception as exc:  # pragma: no cover - network errors
-                self.logger.log("ws_error", risk_level="low", error=str(exc))
+                self._alert("ws_error", exc)
+                if self.alt_ws_url:
+                    self.ws_url = self.alt_ws_url
+                    self.alt_ws_url = None
+                    self.failures = 0
+                    self.logger.log("fallback_success", risk_level="low")
                 time.sleep(1)
             finally:
                 try:
@@ -114,7 +232,9 @@ class CoinbaseWebSocketAdapter(SignalProvider):
                 except Exception:
                     pass
 
-    def fetch(self) -> Dict[str, float]:
+    def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
+        if simulate_failure == "data_poison":
+            return {"coinbase_price": float("nan")}
         with self._lock:
             return dict(self.latest)
 

--- a/adapters/bridge_adapter.py
+++ b/adapters/bridge_adapter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
 
@@ -12,20 +14,61 @@ LOGGER = StructuredLogger("bridge_adapter")
 class BridgeAdapter:
     """Handle token bridging via a third-party API."""
 
-    def __init__(self, api_url: str) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
+
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        LOGGER.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"bridge_adapter:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
 
     # ------------------------------------------------------------------
-    def bridge(self, from_chain: str, to_chain: str, token: str, amount: float) -> Dict[str, Any]:
+    def bridge(
+        self, from_chain: str, to_chain: str, token: str, amount: float, *, simulate_failure: str | None = None
+    ) -> Dict[str, Any]:
         data = {"from": from_chain, "to": to_chain, "token": token, "amount": amount}
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"bridge": "bad"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 503")
 
             resp = requests.post(f"{self.api_url}/bridge", json=data, timeout=5)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOGGER.log("bridge_fail", risk_level="high", error=str(exc))
+            self._alert("bridge_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.post(
+                        f"{self.alt_api_url}/bridge", json=data, timeout=5
+                    )
+                    resp.raise_for_status()
+                    LOGGER.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise
 
 

--- a/adapters/cex_adapter.py
+++ b/adapters/cex_adapter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
 
@@ -12,36 +14,98 @@ LOGGER = StructuredLogger("cex_adapter")
 class CEXAdapter:
     """HTTP-based adapter for a centralized exchange."""
 
-    def __init__(self, api_url: str, api_key: str) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
         self.api_key = api_key
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
+
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        LOGGER.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"cex_adapter:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
 
     # ------------------------------------------------------------------
     def _headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"}
 
     # ------------------------------------------------------------------
-    def get_balance(self) -> Dict[str, Any]:
+    def get_balance(self, *, simulate_failure: str | None = None) -> Dict[str, Any]:
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"balance": "bad"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 429")
 
             resp = requests.get(f"{self.api_url}/balance", headers=self._headers(), timeout=5)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOGGER.log("balance_fail", risk_level="high", error=str(exc))
+            self._alert("balance_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.get(
+                        f"{self.alt_api_url}/balance", headers=self._headers(), timeout=5
+                    )
+                    resp.raise_for_status()
+                    LOGGER.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise
 
     # ------------------------------------------------------------------
-    def place_order(self, side: str, size: float, price: float) -> Dict[str, Any]:
+    def place_order(
+        self, side: str, size: float, price: float, *, simulate_failure: str | None = None
+    ) -> Dict[str, Any]:
         data = {"side": side, "size": size, "price": price}
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"order": "bad"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 503")
 
             resp = requests.post(f"{self.api_url}/order", json=data, headers=self._headers(), timeout=5)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOGGER.log("order_fail", risk_level="high", error=str(exc))
+            self._alert("order_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.post(
+                        f"{self.alt_api_url}/order", json=data, headers=self._headers(), timeout=5
+                    )
+                    resp.raise_for_status()
+                    LOGGER.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise
 

--- a/adapters/dex_adapter.py
+++ b/adapters/dex_adapter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
 
@@ -12,31 +14,102 @@ LOGGER = StructuredLogger("dex_adapter")
 class DEXAdapter:
     """Interact with a DEX aggregator to fetch quotes and execute trades."""
 
-    def __init__(self, api_url: str) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
+
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        LOGGER.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"dex_adapter:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
 
     # ------------------------------------------------------------------
-    def get_quote(self, sell_token: str, buy_token: str, amount: float) -> Dict[str, Any]:
+    def get_quote(
+        self,
+        sell_token: str,
+        buy_token: str,
+        amount: float,
+        *,
+        simulate_failure: str | None = None,
+    ) -> Dict[str, Any]:
         params = {"sellToken": sell_token, "buyToken": buy_token, "amount": amount}
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim network")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc fail")
+            if simulate_failure == "data_poison":
+                return {"price": "NaN"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 503")
 
             resp = requests.get(f"{self.api_url}/quote", params=params, timeout=5)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOGGER.log("quote_fail", risk_level="high", error=str(exc))
+            self._alert("quote_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.get(
+                        f"{self.alt_api_url}/quote", params=params, timeout=5
+                    )
+                    resp.raise_for_status()
+                    LOGGER.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise
 
     # ------------------------------------------------------------------
-    def execute_trade(self, tx_data: Dict[str, Any]) -> Dict[str, Any]:
+    def execute_trade(
+        self,
+        tx_data: Dict[str, Any],
+        *,
+        simulate_failure: str | None = None,
+    ) -> Dict[str, Any]:
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim network")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc fail")
+            if simulate_failure == "data_poison":
+                return {"tx": "invalid"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 503")
 
             resp = requests.post(f"{self.api_url}/swap", json=tx_data, timeout=5)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOGGER.log("trade_fail", risk_level="high", error=str(exc))
+            self._alert("trade_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.post(
+                        f"{self.alt_api_url}/swap", json=tx_data, timeout=5
+                    )
+                    resp.raise_for_status()
+                    LOGGER.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise
 

--- a/adapters/flashloan_adapter.py
+++ b/adapters/flashloan_adapter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
 
@@ -12,13 +14,43 @@ LOG = StructuredLogger("flashloan_adapter")
 class FlashloanAdapter:
     """Execute flashloans to induce price moves for latency farming."""
 
-    def __init__(self, api_url: str) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        *,
+        alt_api_url: str | None = None,
+        ops_agent: OpsAgent | None = None,
+        fail_threshold: int = 3,
+    ) -> None:
         self.api_url = api_url.rstrip("/")
+        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        self.ops_agent = ops_agent
+        self.fail_threshold = fail_threshold
+        self.failures = 0
 
-    def trigger(self, token: str, amount: float) -> Dict[str, Any]:
+    def _alert(self, event: str, err: Exception) -> None:
+        self.failures += 1
+        LOG.log(event, risk_level="high", error=str(err))
+        if self.ops_agent:
+            self.ops_agent.notify(f"flashloan_adapter:{event}:{err}")
+        if self.failures >= self.fail_threshold:
+            raise RuntimeError("circuit breaker open")
+
+    def trigger(
+        self, token: str, amount: float, *, simulate_failure: str | None = None
+    ) -> Dict[str, Any]:
         """Perform the flashloan using an external service."""
         try:
             import requests  # type: ignore
+
+            if simulate_failure == "network":
+                raise RuntimeError("sim net")
+            if simulate_failure == "rpc":
+                raise ValueError("sim rpc")
+            if simulate_failure == "data_poison":
+                return {"flashloan": "bad"}
+            if simulate_failure == "downtime":
+                raise RuntimeError("sim 503")
 
             resp = requests.post(
                 f"{self.api_url}/flashloan",
@@ -28,5 +60,18 @@ class FlashloanAdapter:
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
-            LOG.log("flashloan_fail", risk_level="high", error=str(exc))
+            self._alert("flashloan_fail", exc)
+            if self.alt_api_url:
+                try:
+                    resp = requests.post(
+                        f"{self.alt_api_url}/flashloan",
+                        json={"token": token, "amount": amount},
+                        timeout=5,
+                    )
+                    resp.raise_for_status()
+                    LOG.log("fallback_success", risk_level="low")
+                    self.failures = 0
+                    return resp.json()
+                except Exception as exc2:  # pragma: no cover - network errors
+                    self._alert("fallback_fail", exc2)
             raise

--- a/tests/test_adapters_chaos.py
+++ b/tests/test_adapters_chaos.py
@@ -1,0 +1,171 @@
+import json
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+class DummyOps:
+    def __init__(self):
+        self.msgs = []
+    def notify(self, msg: str) -> None:
+        self.msgs.append(msg)
+
+import importlib.util
+
+BASE = Path(__file__).resolve().parents[1]
+
+def _load(name: str, rel: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / rel)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+
+def _dummy_response(data=None):
+    class Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return data or {}
+
+    return Resp()
+
+
+@pytest.fixture
+def log_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("ERROR_LOG_FILE", str(tmp_path / "errors.log"))
+    core_stub = types.ModuleType("core")
+    core_stub.logger = __import__("core.logger", fromlist=[""])
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    hb = types.ModuleType("hexbytes")
+    hb.HexBytes = bytes
+    monkeypatch.setitem(sys.modules, "hexbytes", hb)
+    rl = types.ModuleType("core.rate_limiter")
+    class RateLimiter:
+        def __init__(self, rate):
+            pass
+        def wait(self):
+            pass
+    rl.RateLimiter = RateLimiter
+    monkeypatch.setitem(sys.modules, "core.rate_limiter", rl)
+    ss = types.ModuleType("core.strategy_scoreboard")
+    class SignalProvider:  # type: ignore
+        pass
+    ss.SignalProvider = SignalProvider
+    monkeypatch.setitem(sys.modules, "core.strategy_scoreboard", ss)
+    return tmp_path
+
+
+def _setup_requests(monkeypatch, success_url, data=None):
+    def fake_get(url, *a, **k):
+        if success_url in url:
+            return _dummy_response(data or {"ok": True})
+        raise RuntimeError("fail")
+
+    def fake_post(url, *a, **k):
+        if success_url in url:
+            return _dummy_response(data or {"ok": True})
+        raise RuntimeError("fail")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=fake_get, post=fake_post),
+    )
+
+
+def test_dex_adapter_fallback(monkeypatch, log_env):
+    _setup_requests(monkeypatch, "alt", {"ok": True})
+    ops = DummyOps()
+    DEXAdapter = _load("dex_adapter", "adapters/dex_adapter.py").DEXAdapter
+    adapter = DEXAdapter("http://bad", alt_api_url="http://alt", ops_agent=ops)
+    data = adapter.get_quote("ETH", "USDC", 1, simulate_failure="network")
+    assert data.get("ok") is True
+    assert adapter.failures == 0
+
+
+def test_cex_adapter_circuit(monkeypatch, log_env):
+    _setup_requests(monkeypatch, "alt", {"ok": True})
+    ops = DummyOps()
+    CEXAdapter = _load("cex_adapter", "adapters/cex_adapter.py").CEXAdapter
+    adapter = CEXAdapter(
+        "http://bad",
+        "k",
+        alt_api_url="http://alt",
+        ops_agent=ops,
+        fail_threshold=1,
+    )
+    with pytest.raises(RuntimeError):
+        adapter.get_balance(simulate_failure="network")
+    assert adapter.failures == 1
+
+
+def test_bridge_adapter_manual(monkeypatch, log_env):
+    _setup_requests(monkeypatch, "alt", {"ok": True})
+    ops = DummyOps()
+    BridgeAdapter = _load("bridge_adapter", "adapters/bridge_adapter.py").BridgeAdapter
+    adapter = BridgeAdapter("http://bad", alt_api_url="http://alt", ops_agent=ops)
+    data = adapter.bridge("eth", "arb", "ETH", 1, simulate_failure="network")
+    assert data.get("ok") is True
+
+
+def test_pool_scanner_downtime(monkeypatch, log_env):
+    _setup_requests(monkeypatch, "alt", [{"pool": "bad", "domain": "x"}])
+    ops = DummyOps()
+    PoolScanner = _load("pool_scanner", "adapters/pool_scanner.py").PoolScanner
+    scanner = PoolScanner("http://bad", alt_api_url="http://alt", ops_agent=ops)
+    pools = scanner.scan(simulate_failure="downtime")
+    assert pools and pools[0].pool == "bad"
+
+
+def test_mempool_monitor_rpc(monkeypatch, log_env):
+    ops = DummyOps()
+    MempoolMonitor = _load("mempool_monitor", "core/mempool_monitor.py").MempoolMonitor
+    monitor = MempoolMonitor(None, ops_agent=ops, fail_threshold=1)
+    assert monitor.listen_bridge_txs(simulate_failure="rpc") == []
+
+
+def test_alpha_signal(monkeypatch, log_env):
+    _setup_requests(monkeypatch, "alt", {"ok": True})
+    ops = DummyOps()
+    DuneAnalyticsAdapter = _load("alpha_signals", "adapters/alpha_signals.py").DuneAnalyticsAdapter
+    WhaleAlertAdapter = _load("alpha_signals", "adapters/alpha_signals.py").WhaleAlertAdapter
+    dune = DuneAnalyticsAdapter(
+        "http://bad",
+        "k",
+        "q",
+        alt_api_url="http://alt",
+        ops_agent=ops,
+    )
+    data = dune.fetch(simulate_failure="network")
+    assert data == {}
+    whale = WhaleAlertAdapter(
+        "http://bad",
+        "k",
+        alt_api_url="http://alt",
+        ops_agent=ops,
+    )
+    data2 = whale.fetch(simulate_failure="network")
+    assert data2 == {"whale_flow": 0.0}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulate", default="")
+    args = parser.parse_args()
+    if args.simulate == "bridge_downtime":
+        BridgeAdapter("http://x").bridge("e", "a", "T", 1, simulate_failure="downtime")
+    elif args.simulate:
+        print("unknown simulation")
+


### PR DESCRIPTION
## Summary
- add chaos hooks and fallback handling across adapters
- document adapter chaos runbook in README/AGENTS
- provide tests for adapter failure simulation
- expose chaos test target in Makefile

## Testing
- `pytest tests/test_logger.py tests/test_adapters_chaos.py -q`
