### PR TITLE
Add chaos scheduler and multi-endpoint fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,14 @@ Every PR or batch/module must pass:
   `python tests/test_adapters_chaos.py --simulate bridge_downtime`
 * Expect `fallback_success` events in module logs and OpsAgent alerts for each failure.
 
+### chaos_scheduler
+
+* Run scheduler:
+  `CHAOS_ONCE=1 python infra/sim_harness/chaos_scheduler.py`
+* Configure via ENV:
+  `CHAOS_INTERVAL`, `CHAOS_ADAPTERS`, `CHAOS_MODES`, `CHAOS_SCHED_LOG`.
+* Scheduler logs to `logs/chaos_scheduler.json` and updates `logs/drill_metrics.json`.
+
 ### OpsAgent & CapitalLock Runbook
 
 * Start OpsAgent:

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ the values used in tests and the simulation harness:
 | `FLASHBOTS_AUTH_KEY` | `<none>` | Private key for Flashbots bundles |
 | `FLASHBOTS_RPC_URL` | `https://relay.flashbots.net` | Flashbots/SUAVE relay |
 | `PRIORITY_FEE_GWEI` | `2` | Default EIP-1559 priority fee |
+| `CHAOS_INTERVAL` | `600` | Seconds between scheduled chaos runs |
+| `CHAOS_ADAPTERS` | `dex,bridge,cex,flashloan` | Adapters to target |
+| `CHAOS_MODES` | `network,rpc,downtime,data_poison` | Failure modes injected |
+| `CHAOS_SCHED_LOG` | `logs/chaos_scheduler.json` | Chaos scheduler log path |
 
 ### cross_domain_arb Runbook
 
@@ -503,8 +507,17 @@ During a network outage the logs include entries like:
 {"event":"fallback_success","module":"dex_adapter","risk_level":"low"}
 ```
 
-Metrics from the chaos run are written to `logs/drill_metrics.json` and OpsAgent
-dispatches alerts for each failure.
+Metrics from the chaos run are written to `logs/drill_metrics.json` and OpsAgent dispatches alerts for each failure.
+
+### Chaos Scheduler
+
+Run scheduled chaos injections that randomly target adapters and failure modes:
+
+```bash
+CHAOS_ONCE=1 python infra/sim_harness/chaos_scheduler.py
+```
+
+Set `CHAOS_INTERVAL` (seconds), `CHAOS_ADAPTERS`, and `CHAOS_MODES` to control frequency and scope. Scheduler logs to `logs/chaos_scheduler.json` and updates `logs/drill_metrics.json` on each run.
 
 ## OpsAgent & CapitalLock
 

--- a/adapters/bridge_adapter.py
+++ b/adapters/bridge_adapter.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import os
+import random
+from typing import Any, Dict, List
 
 from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
+from ai.mutation_log import log_mutation
 
 LOGGER = StructuredLogger("bridge_adapter")
 
@@ -19,11 +22,17 @@ class BridgeAdapter:
         api_url: str,
         *,
         alt_api_url: str | None = None,
+        alt_api_urls: List[str] | None = None,
         ops_agent: OpsAgent | None = None,
         fail_threshold: int = 3,
     ) -> None:
         self.api_url = api_url.rstrip("/")
-        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        alts = []
+        if alt_api_urls:
+            alts.extend(alt_api_urls)
+        if alt_api_url:
+            alts.append(alt_api_url)
+        self.alt_api_urls = [a.rstrip("/") for a in alts]
         self.ops_agent = ops_agent
         self.fail_threshold = fail_threshold
         self.failures = 0
@@ -58,17 +67,29 @@ class BridgeAdapter:
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("bridge_fail", exc)
-            if self.alt_api_url:
+            for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
-                    resp = requests.post(
-                        f"{self.alt_api_url}/bridge", json=data, timeout=5
-                    )
+                    LOGGER.log("fallback_try", risk_level="low", alt=alt)
+                    resp = requests.post(f"{alt}/bridge", json=data, timeout=5)
                     resp.raise_for_status()
-                    LOGGER.log("fallback_success", risk_level="low")
+                    LOGGER.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
+                    log_mutation(
+                        "adapter_chaos",
+                        adapter="bridge_adapter",
+                        failure=simulate_failure or "runtime",
+                        fallback="success",
+                    )
                     return resp.json()
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
+            os.environ["OPS_CRITICAL_EVENT"] = "1"
+            log_mutation(
+                "adapter_chaos",
+                adapter="bridge_adapter",
+                failure=simulate_failure or "runtime",
+                fallback="fail",
+            )
             raise
 
 

--- a/adapters/flashloan_adapter.py
+++ b/adapters/flashloan_adapter.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import os
+import random
+from typing import Any, Dict, List
 
 from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
+from ai.mutation_log import log_mutation
 
 LOG = StructuredLogger("flashloan_adapter")
 
@@ -19,11 +22,17 @@ class FlashloanAdapter:
         api_url: str,
         *,
         alt_api_url: str | None = None,
+        alt_api_urls: List[str] | None = None,
         ops_agent: OpsAgent | None = None,
         fail_threshold: int = 3,
     ) -> None:
         self.api_url = api_url.rstrip("/")
-        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        alts = []
+        if alt_api_urls:
+            alts.extend(alt_api_urls)
+        if alt_api_url:
+            alts.append(alt_api_url)
+        self.alt_api_urls = [a.rstrip("/") for a in alts]
         self.ops_agent = ops_agent
         self.fail_threshold = fail_threshold
         self.failures = 0
@@ -61,17 +70,31 @@ class FlashloanAdapter:
             return resp.json()
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("flashloan_fail", exc)
-            if self.alt_api_url:
+            for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
+                    LOG.log("fallback_try", risk_level="low", alt=alt)
                     resp = requests.post(
-                        f"{self.alt_api_url}/flashloan",
+                        f"{alt}/flashloan",
                         json={"token": token, "amount": amount},
                         timeout=5,
                     )
                     resp.raise_for_status()
-                    LOG.log("fallback_success", risk_level="low")
+                    LOG.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
+                    log_mutation(
+                        "adapter_chaos",
+                        adapter="flashloan_adapter",
+                        failure=simulate_failure or "runtime",
+                        fallback="success",
+                    )
                     return resp.json()
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
+            os.environ["OPS_CRITICAL_EVENT"] = "1"
+            log_mutation(
+                "adapter_chaos",
+                adapter="flashloan_adapter",
+                failure=simulate_failure or "runtime",
+                fallback="fail",
+            )
             raise

--- a/adapters/pool_scanner.py
+++ b/adapters/pool_scanner.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
+import random
 from typing import List
 
 from agents.ops_agent import OpsAgent
 
 from core.logger import StructuredLogger
+from ai.mutation_log import log_mutation
 
 LOG = StructuredLogger("pool_scanner")
 
@@ -26,11 +29,17 @@ class PoolScanner:
         api_url: str,
         *,
         alt_api_url: str | None = None,
+        alt_api_urls: List[str] | None = None,
         ops_agent: OpsAgent | None = None,
         fail_threshold: int = 3,
     ) -> None:
         self.api_url = api_url.rstrip("/")
-        self.alt_api_url = alt_api_url.rstrip("/") if alt_api_url else None
+        alts = []
+        if alt_api_urls:
+            alts.extend(alt_api_urls)
+        if alt_api_url:
+            alts.append(alt_api_url)
+        self.alt_api_urls = [a.rstrip("/") for a in alts]
         self.ops_agent = ops_agent
         self.fail_threshold = fail_threshold
         self.failures = 0
@@ -62,16 +71,30 @@ class PoolScanner:
             return [PoolInfo(**d) for d in data]
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("scan_fail", exc)
-            if self.alt_api_url:
+            for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
-                    resp = requests.get(f"{self.alt_api_url}/pools", timeout=5)
+                    LOG.log("fallback_try", risk_level="low", alt=alt)
+                    resp = requests.get(f"{alt}/pools", timeout=5)
                     resp.raise_for_status()
-                    LOG.log("fallback_success", risk_level="low")
+                    LOG.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
                     data = resp.json()
+                    log_mutation(
+                        "adapter_chaos",
+                        adapter="pool_scanner",
+                        failure=simulate_failure or "runtime",
+                        fallback="success",
+                    )
                     return [PoolInfo(**d) for d in data]
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
+            os.environ["OPS_CRITICAL_EVENT"] = "1"
+            log_mutation(
+                "adapter_chaos",
+                adapter="pool_scanner",
+                failure=simulate_failure or "runtime",
+                fallback="fail",
+            )
             return []
 
     def scan_l3(self, *, simulate_failure: str | None = None) -> List[PoolInfo]:
@@ -94,14 +117,28 @@ class PoolScanner:
             return [PoolInfo(**d) for d in data]
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("scan_l3_fail", exc)
-            if self.alt_api_url:
+            for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
-                    resp = requests.get(f"{self.alt_api_url}/l3_pools", timeout=5)
+                    LOG.log("fallback_try", risk_level="low", alt=alt)
+                    resp = requests.get(f"{alt}/l3_pools", timeout=5)
                     resp.raise_for_status()
-                    LOG.log("fallback_success", risk_level="low")
+                    LOG.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
                     data = resp.json()
+                    log_mutation(
+                        "adapter_chaos",
+                        adapter="pool_scanner",
+                        failure=simulate_failure or "runtime",
+                        fallback="success",
+                    )
                     return [PoolInfo(**d) for d in data]
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
+            os.environ["OPS_CRITICAL_EVENT"] = "1"
+            log_mutation(
+                "adapter_chaos",
+                adapter="pool_scanner",
+                failure=simulate_failure or "runtime",
+                fallback="fail",
+            )
             return []

--- a/agents/gatekeeper.py
+++ b/agents/gatekeeper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from core.logger import StructuredLogger
 from core.tx_engine.kill_switch import kill_switch_triggered
 from .capital_lock import CapitalLock
@@ -15,6 +16,9 @@ def gates_green(lock: CapitalLock, ops: OpsAgent, drp: DRPAgent) -> bool:
     """Return ``True`` if all agent gates allow execution."""
     if kill_switch_triggered():
         LOGGER.log("kill_switch", risk_level="high")
+        return False
+    if os.getenv("OPS_CRITICAL_EVENT") == "1":
+        LOGGER.log("ops_critical", risk_level="high")
         return False
     if not lock.trade_allowed():
         LOGGER.log("capital_lock", risk_level="high")

--- a/ai/mutation_manager.py
+++ b/ai/mutation_manager.py
@@ -18,6 +18,7 @@ class MutationManager:
         self.num_agents = num_agents
         self.agents: List[Any] = []
         self.scores: Dict[int, float] = {}
+        self.chaos_counts: Dict[str, int] = {}
 
     # --------------------------------------------------------------
     def spawn_agents(self, agent_class: Type[Any]) -> None:
@@ -54,3 +55,14 @@ class MutationManager:
             return
         log_mutation("trigger_mutation", strategies=strategies)
         LOG.log("trigger_mutation", strategies=strategies)
+
+    # --------------------------------------------------------------
+    def record_chaos_event(self, adapter: str, event: str) -> None:
+        """Track adapter chaos events and emit mutation hooks."""
+        count = self.chaos_counts.get(adapter, 0) + 1
+        self.chaos_counts[adapter] = count
+        log_mutation("adapter_chaos_event", adapter=adapter, event=event, count=count)
+        LOG.log("adapter_chaos_event", adapter=adapter, event=event, count=count)
+        if count >= 3:
+            log_mutation("adapter_chaos_mutation", adapter=adapter)
+            LOG.log("adapter_chaos_mutation", adapter=adapter)

--- a/infra/sim_harness/chaos_scheduler.py
+++ b/infra/sim_harness/chaos_scheduler.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Scheduled chaos injection harness."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Callable, Dict
+
+from agents.ops_agent import OpsAgent
+from core.logger import StructuredLogger, make_json_safe
+from adapters import DEXAdapter, BridgeAdapter, CEXAdapter, FlashloanAdapter
+from ai.mutation_log import log_mutation
+
+LOGGER = StructuredLogger("chaos_scheduler", log_file=os.getenv("CHAOS_SCHED_LOG", "logs/chaos_scheduler.json"))
+METRICS_FILE = Path(os.getenv("CHAOS_METRICS", "logs/drill_metrics.json"))
+
+OPS = OpsAgent({})
+
+
+ADAPTER_FUNCS: Dict[str, Callable[[str], None]] = {
+    "dex": lambda mode: DEXAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).get_quote("ETH", "USDC", 1, simulate_failure=mode),
+    "bridge": lambda mode: BridgeAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).bridge("eth", "arb", "ETH", 1, simulate_failure=mode),
+    "cex": lambda mode: CEXAdapter("http://bad", "k", alt_api_urls=["http://alt"], ops_agent=OPS).get_balance(simulate_failure=mode),
+    "flashloan": lambda mode: FlashloanAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).trigger("ETH", 1, simulate_failure=mode),
+}
+
+
+def _update_metrics(adapter: str) -> None:
+    metrics: Dict[str, Dict[str, int]] = {}
+    if METRICS_FILE.exists():
+        try:
+            metrics = json.loads(METRICS_FILE.read_text())
+        except Exception:
+            metrics = {}
+    metrics.setdefault(adapter, {"failures": 0})
+    metrics[adapter]["failures"] += 1
+    METRICS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    METRICS_FILE.write_text(json.dumps(make_json_safe(metrics), indent=2))
+
+
+def run_once() -> None:
+    adapters = [a.strip() for a in os.getenv("CHAOS_ADAPTERS", "dex,bridge,cex,flashloan").split(",") if a.strip()]
+    modes = [m.strip() for m in os.getenv("CHAOS_MODES", "network,rpc,downtime,data_poison").split(",") if m.strip()]
+    adapter = random.choice(adapters)
+    mode = random.choice(modes)
+    LOGGER.log("chaos_start", adapter=adapter, mode=mode)
+    try:
+        ADAPTER_FUNCS[adapter](mode)
+        fallback = "success"
+    except Exception as exc:  # pragma: no cover - runtime
+        fallback = "fail"
+        OPS.notify(f"chaos_fail:{adapter}:{exc}")
+        os.environ["OPS_CRITICAL_EVENT"] = "1"
+    _update_metrics(adapter)
+    log_mutation("adapter_chaos", adapter=adapter, failure=mode, fallback=fallback)
+    LOGGER.log("chaos_complete", adapter=adapter, mode=mode, fallback=fallback)
+
+
+def main() -> None:
+    interval = int(os.getenv("CHAOS_INTERVAL", "600"))
+    once = os.getenv("CHAOS_ONCE") == "1"
+    while True:
+        run_once()
+        if once:
+            break
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adapters_chaos.py
+++ b/tests/test_adapters_chaos.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import types
 import importlib.util
+import json
 
 import pytest
 
@@ -11,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 class DummyOps:
     def __init__(self):
         self.msgs = []
+
     def notify(self, msg: str) -> None:
         self.msgs.append(msg)
 
@@ -93,6 +95,33 @@ def test_dex_adapter_fallback(monkeypatch, log_env):
     assert adapter.failures == 0
 
 
+def test_multi_endpoint_fallback(monkeypatch, log_env):
+    calls = []
+
+    def fake_get(url, *a, **k):
+        calls.append(url)
+        if "alt2" in url:
+            return _dummy_response({"ok": True})
+        raise RuntimeError("fail")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=fake_get, post=fake_get),
+    )
+    ops = DummyOps()
+    DEXAdapter = _load("dex_adapter", "adapters/dex_adapter.py").DEXAdapter
+    monkeypatch.setattr("random.sample", lambda l, k: l)
+    adapter = DEXAdapter(
+        "http://bad",
+        alt_api_urls=["http://alt1", "http://alt2"],
+        ops_agent=ops,
+    )
+    data = adapter.get_quote("ETH", "USDC", 1, simulate_failure="network")
+    assert data.get("ok") is True
+    assert any("alt1" in c for c in calls)
+
+
 def test_cex_adapter_circuit(monkeypatch, log_env):
     _setup_requests(monkeypatch, "alt", {"ok": True})
     ops = DummyOps()
@@ -156,6 +185,18 @@ def test_alpha_signal(monkeypatch, log_env):
     )
     data2 = whale.fetch(simulate_failure="network")
     assert data2 == {"whale_flow": 0.0}
+
+
+def test_chaos_scheduler(monkeypatch, tmp_path, log_env):
+    _setup_requests(monkeypatch, "alt")
+    scheduler = _load("chaos_scheduler", "infra/sim_harness/chaos_scheduler.py")
+    monkeypatch.setenv("CHAOS_ADAPTERS", "dex")
+    monkeypatch.setenv("CHAOS_MODES", "network")
+    monkeypatch.setenv("CHAOS_SCHED_LOG", str(tmp_path / "sched.json"))
+    monkeypatch.setenv("CHAOS_METRICS", str(tmp_path / "metrics.json"))
+    scheduler.run_once()
+    metrics = json.loads(Path(tmp_path / "metrics.json").read_text())
+    assert metrics["dex"]["failures"] >= 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enhance adapter fallback with multiple endpoints, mutation logging and OPS alerts
- add circuit gating via `OPS_CRITICAL_EVENT`
- implement `chaos_scheduler.py` for scheduled chaos drills
- document new scheduler and env vars
- extend chaos tests for multi-endpoint and scheduler

## Testing
- `pytest -v` *(fails: ModuleNotFoundError and other runtime errors)*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python ai/audit_agent.py --mode=offline --logs logs/chaos_scheduler.json`