### PR TITLE
Refactor imports and remove path hacks

### DIFF
--- a/agents/ops_agent.py
+++ b/agents/ops_agent.py
@@ -50,7 +50,7 @@ class OpsAgent:
         webhook = os.getenv("OPS_ALERT_WEBHOOK")
         if webhook:
             try:
-                import requests  # type: ignore
+                import requests  # type: ignore[import-untyped]
 
                 requests.post(webhook, json={"text": message}, timeout=5)
             except Exception as exc:  # pragma: no cover - network errors

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,3 @@
 """MEV-OG core package."""
 
-from .orchestrator import StrategyOrchestrator
-
-__all__ = ["StrategyOrchestrator"]
+__all__: list[str] = []

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -64,7 +64,7 @@ def load_config(path: str) -> Dict[str, Any]:
     """Load YAML config from ``path`` using PyYAML if available."""
 
     try:
-        import yaml  # type: ignore
+        import yaml  # type: ignore[import-untyped]
     except Exception:  # pragma: no cover - optional
         yaml = cast(Any, None)
     text = Path(path).read_text()

--- a/infra/sim_harness/fork_sim_cross_arb.py
+++ b/infra/sim_harness/fork_sim_cross_arb.py
@@ -1,11 +1,9 @@
 """Fork simulation for cross-domain arbitrage detection."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.cross_domain_arb.strategy import CrossDomainArb, PoolConfig, BridgeConfig
 

--- a/infra/sim_harness/fork_sim_cross_rollup_superbot.py
+++ b/infra/sim_harness/fork_sim_cross_rollup_superbot.py
@@ -1,11 +1,9 @@
 """Fork simulation for cross_rollup_superbot."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.cross_rollup_superbot.strategy import (
     CrossRollupSuperbot,

--- a/infra/sim_harness/fork_sim_kill.py
+++ b/infra/sim_harness/fork_sim_kill.py
@@ -1,9 +1,6 @@
 """Simulates forked mainnet kill switch testing for MEV-OG."""
 
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from core.tx_engine.kill_switch import (
     init_kill_switch,

--- a/infra/sim_harness/fork_sim_kill_switch_sh.py
+++ b/infra/sim_harness/fork_sim_kill_switch_sh.py
@@ -5,10 +5,8 @@ if the switch is active. Intended for chaos testing and DRP drills.
 """
 
 import subprocess
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from core.tx_engine.kill_switch import init_kill_switch, kill_switch_triggered, record_kill_event
 

--- a/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
+++ b/infra/sim_harness/fork_sim_l3_app_rollup_mev.py
@@ -1,11 +1,9 @@
 """Fork simulation for L3AppRollupMEV."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.l3_app_rollup_mev.strategy import (
     L3AppRollupMEV,

--- a/infra/sim_harness/fork_sim_l3_sequencer_mev.py
+++ b/infra/sim_harness/fork_sim_l3_sequencer_mev.py
@@ -1,11 +1,9 @@
 """Fork simulation for l3_sequencer_mev."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.l3_sequencer_mev.strategy import L3SequencerMEV, PoolConfig
 

--- a/infra/sim_harness/fork_sim_nft_liquidation.py
+++ b/infra/sim_harness/fork_sim_nft_liquidation.py
@@ -1,11 +1,9 @@
 """Fork simulation for nft_liquidation."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.nft_liquidation.strategy import NFTLiquidationMEV, AuctionConfig
 

--- a/infra/sim_harness/fork_sim_nonce.py
+++ b/infra/sim_harness/fork_sim_nonce.py
@@ -1,10 +1,7 @@
 """Forked mainnet simulation validating nonce drift recovery."""
 
 import os
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from core.tx_engine.nonce_manager import NonceManager
 

--- a/infra/sim_harness/fork_sim_rwa_settlement.py
+++ b/infra/sim_harness/fork_sim_rwa_settlement.py
@@ -1,11 +1,9 @@
 """Fork simulation for rwa_settlement."""
 
 import os
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from strategies.rwa_settlement.strategy import RWASettlementMEV, VenueConfig
 

--- a/infra/sim_harness/fork_sim_tx.py
+++ b/infra/sim_harness/fork_sim_tx.py
@@ -6,11 +6,6 @@ transaction using TransactionBuilder. Requires web3 and a forking provider
 """
 
 import os
-import sys
-
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from core.tx_engine.builder import TransactionBuilder, HexBytes
 from core.tx_engine.nonce_manager import NonceManager

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/test_adapters_chaos.py
+++ b/tests/test_adapters_chaos.py
@@ -8,7 +8,6 @@ import json
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 class DummyOps:
@@ -121,7 +120,7 @@ def test_multi_endpoint_fallback(monkeypatch, log_env):
     )
     ops = DummyOps()
     DEXAdapter = _load("dex_adapter", "adapters/dex_adapter.py").DEXAdapter
-    monkeypatch.setattr("random.sample", lambda l, k: l)
+    monkeypatch.setattr("random.sample", lambda items, k: items)
     adapter = DEXAdapter(
         "http://bad",
         alt_api_urls=["http://alt1", "http://alt2"],

--- a/tests/test_alpha_dashboard.py
+++ b/tests/test_alpha_dashboard.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
-
 import pytest
 pytest.importorskip("hexbytes")
 

--- a/tests/test_audit_agent.py
+++ b/tests/test_audit_agent.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai.audit_agent import AuditAgent
 from core.logger import StructuredLogger

--- a/tests/test_batch_ops.py
+++ b/tests/test_batch_ops.py
@@ -3,7 +3,6 @@ import subprocess
 from pathlib import Path
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "batch_ops.py"
 

--- a/tests/test_bundle_submission.py
+++ b/tests/test_bundle_submission.py
@@ -1,8 +1,6 @@
 import sys
 import types
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
 

--- a/tests/test_capital_lock.py
+++ b/tests/test_capital_lock.py
@@ -1,7 +1,4 @@
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from agents.capital_lock import CapitalLock
 import json

--- a/tests/test_capital_lock_integration.py
+++ b/tests/test_capital_lock_integration.py
@@ -1,9 +1,7 @@
 import json
 import os
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_ci_prune_score.py
+++ b/tests/test_ci_prune_score.py
@@ -1,6 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai.mutation_manager import MutationManager
 

--- a/tests/test_cross_domain_arb.py
+++ b/tests/test_cross_domain_arb.py
@@ -1,10 +1,7 @@
 import os
-from pathlib import Path
-import sys
 import pytest
 pytest.importorskip("hexbytes")
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.cross_domain_arb import CrossDomainArb, PoolConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_cross_rollup_superbot.py
+++ b/tests/test_cross_rollup_superbot.py
@@ -5,7 +5,6 @@ import types
 from pathlib import Path
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_drp_time.py
+++ b/tests/test_drp_time.py
@@ -5,10 +5,8 @@ import io
 import time
 import json
 from pathlib import Path
-import sys
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "rollback.sh"
 

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -1,7 +1,4 @@
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from agents.capital_lock import CapitalLock
 from agents.ops_agent import OpsAgent

--- a/tests/test_intent_classifier_live.py
+++ b/tests/test_intent_classifier_live.py
@@ -1,7 +1,4 @@
-from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai import intent_classifier
 

--- a/tests/test_json_safe.py
+++ b/tests/test_json_safe.py
@@ -1,8 +1,5 @@
 import json
-from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.logger import StructuredLogger, log_error
 

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -2,10 +2,7 @@
 
 import json
 import importlib
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 import core.tx_engine.kill_switch as ks
 

--- a/tests/test_l3_app_rollup_mev.py
+++ b/tests/test_l3_app_rollup_mev.py
@@ -4,7 +4,6 @@ import types
 from pathlib import Path
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.l3_app_rollup_mev import L3AppRollupMEV, PoolConfig, BridgeConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_l3_sequencer_mev.py
+++ b/tests/test_l3_sequencer_mev.py
@@ -1,9 +1,7 @@
 import json
 import tempfile
 from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.l3_sequencer_mev import L3SequencerMEV, PoolConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -4,9 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core.logger import StructuredLogger, register_hook
 import pytest

--- a/tests/test_meta_orchestrator.py
+++ b/tests/test_meta_orchestrator.py
@@ -1,7 +1,4 @@
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core.meta_orchestrator import MetaOrchestrator
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,10 +1,7 @@
 """Tests for Prometheus metrics server."""
 
 import urllib.request
-from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core import metrics
 import importlib

--- a/tests/test_mutation_log.py
+++ b/tests/test_mutation_log.py
@@ -1,8 +1,5 @@
 import json
-from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai.mutation_manager import MutationManager
 

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,9 +1,6 @@
 """Tests for strategy scoring and pruning utilities."""
 
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai.mutator import score_strategies, prune_strategies
 

--- a/tests/test_mutator_llm.py
+++ b/tests/test_mutator_llm.py
@@ -1,7 +1,5 @@
 import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from ai.mutator.mutator import Mutator
 

--- a/tests/test_mutator_main.py
+++ b/tests/test_mutator_main.py
@@ -1,10 +1,7 @@
 """Tests for the mutation cycle orchestrator."""
 
-import sys
 import json
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 import ai.mutator.main as mut_main
 
@@ -21,7 +18,9 @@ def test_mutation_cycle(monkeypatch, tmp_path):
     (strat_dir / "strategy.py").write_text(
         "class Good:\n" "    def __init__(self, pools=None):\n        pass\n" "    def mutate(self, params):\n        pass\n"
     )
-    sys.path.insert(0, str(tmp_path))
+    import strategies
+    from pkgutil import extend_path
+    strategies.__path__ = extend_path(strategies.__path__, str(tmp_path / "strategies"))
 
     monkeypatch.setenv("ERROR_LOG_FILE", str(logs / "errors.log"))
     monkeypatch.setenv("FOUNDER_APPROVED", "1")
@@ -60,7 +59,9 @@ def test_mutation_cycle_requires_founder(monkeypatch, tmp_path):
     strat_dir.mkdir(parents=True)
     (strat_dir / "__init__.py").write_text("")
     (strat_dir / "strategy.py").write_text("class Good:\n    pass\n")
-    sys.path.insert(0, str(tmp_path))
+    import strategies
+    from pkgutil import extend_path
+    strategies.__path__ = extend_path(strategies.__path__, str(tmp_path / "strategies"))
 
     monkeypatch.setenv("ERROR_LOG_FILE", str(logs / "errors.log"))
     monkeypatch.setenv("FOUNDER_APPROVED", "0")

--- a/tests/test_nft_liquidation.py
+++ b/tests/test_nft_liquidation.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import sys
 import types
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.nft_liquidation import NFTLiquidationMEV, AuctionConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -2,10 +2,7 @@
 
 import json
 import threading
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core.tx_engine.nonce_manager import NonceManager
 

--- a/tests/test_ops_agent.py
+++ b/tests/test_ops_agent.py
@@ -1,7 +1,5 @@
 import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from agents.ops_agent import OpsAgent
 from core.logger import register_hook

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,7 +1,6 @@
+import importlib.util
 import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core.orchestrator import StrategyOrchestrator
 
@@ -15,10 +14,18 @@ def _make_dummy_strategy(tmp_path):
         "    def __init__(self, **kw):\n        self.runs=0\n" \
         "    def run_once(self):\n        self.runs+=1\n"
     )
-    sys.path.insert(0, str(tmp_path))
     import strategies
     from pkgutil import extend_path
-    strategies.__path__ = extend_path(strategies.__path__, strategies.__name__)
+    strategies.__path__ = extend_path(
+        strategies.__path__, str(tmp_path / "strategies")
+    )
+    spec = importlib.util.spec_from_file_location(
+        "strategies.dummy.strategy", strat_dir / "strategy.py"
+    )
+    if spec and spec.loader:
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["strategies.dummy.strategy"] = mod
+        spec.loader.exec_module(mod)
 
 
 def _config(tmp_path):

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,8 +1,5 @@
 import time
-from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from core.rate_limiter import RateLimiter
 

--- a/tests/test_replay_arms_race.py
+++ b/tests/test_replay_arms_race.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import sys
 import os
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "replay_arms_race.py"
 

--- a/tests/test_rwa_settlement.py
+++ b/tests/test_rwa_settlement.py
@@ -4,7 +4,6 @@ import types
 from pathlib import Path
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from strategies.rwa_settlement import RWASettlementMEV, VenueConfig
 from agents.capital_lock import CapitalLock

--- a/tests/test_strategy_scoreboard.py
+++ b/tests/test_strategy_scoreboard.py
@@ -1,10 +1,8 @@
 from pathlib import Path
 
-import sys
 
 import pytest
 pytest.importorskip("hexbytes")
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.strategy_scoreboard import (
     StrategyScoreboard,

--- a/tests/test_tx_engine.py
+++ b/tests/test_tx_engine.py
@@ -3,9 +3,7 @@
 import json
 from pathlib import Path
 import threading
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 import pytest
 from agents.agent_registry import set_value


### PR DESCRIPTION
## Summary
- drop indirect orchestrator import
- load dummy strategies via importlib
- create tests package so root path injection not needed
- remove unused sys.path modifications and rename loop variable
- clean up ops_agent and orchestrator imports

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: 11 failed, 98 passed, 2 skipped)*