### PR TITLE
Add typing hints to tests

### DIFF
--- a/adapters/alpha_signals.py
+++ b/adapters/alpha_signals.py
@@ -58,7 +58,7 @@ class DuneAnalyticsAdapter(SignalProvider):
     def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
         self.rate.wait()
         try:
-            import requests  # type: ignore
+            import requests
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/ai/mutator/mutator.py
+++ b/ai/mutator/mutator.py
@@ -52,7 +52,7 @@ class Mutator:
             return json.dumps({"params": {}})
 
         try:
-            import openai as openai_module  # pragma: no cover - external
+            import openai as openai_module  # type: ignore  # pragma: no cover - external
             openai_client = cast(Any, openai_module)
 
             openai_client.api_key = get_secret("OPENAI_API_KEY")

--- a/tests/test_bundle_submission.py
+++ b/tests/test_bundle_submission.py
@@ -5,24 +5,24 @@ import types
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
 
 class DummyFlashbots:
-    def __init__(self):
-        self.sent = []
+    def __init__(self) -> None:
+        self.sent: list[tuple[list[str], int]] = []
 
-    def send_bundle(self, bundle, target_block):
+    def send_bundle(self, bundle: list[str], target_block: int) -> dict[str, str]:
         self.sent.append((bundle, target_block))
         return {"bundleHash": "hash"}
 
 class DummyEth:
-    def __init__(self):
+    def __init__(self) -> None:
         self.block_number = 1
 
 class DummyWeb3:
-    def __init__(self):
+    def __init__(self) -> None:
         self.eth = DummyEth()
         self.flashbots = DummyFlashbots()
 
 
-def test_bundle_send(monkeypatch):
+def test_bundle_send(monkeypatch) -> None:
     module = types.ModuleType("flashbots")
 
     def flashbot(w3, account, endpoint_uri=None):
@@ -50,7 +50,7 @@ def test_bundle_send(monkeypatch):
     assert latency >= 0
     assert w3.flashbots.sent
 
-def test_bundle_fallback(monkeypatch):
+def test_bundle_fallback(monkeypatch) -> None:
     module = types.ModuleType("flashbots")
 
     class FB:

--- a/tests/test_capital_lock_integration.py
+++ b/tests/test_capital_lock_integration.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from typing import Callable
 
 
 from strategies.cross_rollup_superbot import CrossRollupSuperbot, PoolConfig, BridgeConfig
@@ -9,65 +10,65 @@ from core.oracles.uniswap_feed import PriceData
 
 
 class DummyPool:
-    def __init__(self, price):
+    def __init__(self, price: float) -> None:
         self._price = price
 
     class functions:
-        def __init__(self, outer):
+        def __init__(self, outer: "DummyPool") -> None:
             self.outer = outer
 
-        def slot0(self):
+        def slot0(self) -> Callable[[], tuple[int, int, int, int, int, int, bool]]:
             return lambda: (self.outer._price, 0, 0, 0, 0, 0, False)
 
-        def token0(self):
+        def token0(self) -> Callable[[], str]:
             return lambda: "0x0"
 
-        def token1(self):
+        def token1(self) -> Callable[[], str]:
             return lambda: "0x1"
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str):
         return getattr(self.functions(self), item)
 
 
 class DummyEth:
-    def __init__(self, price):
+    def __init__(self, price: float) -> None:
         self.contract_obj = DummyPool(price)
         self.block_number = 1
 
-    def contract(self, address, abi):
+    def contract(self, address: str, abi: object) -> DummyPool:
         return self.contract_obj
 
-    def get_block(self, block):
+    def get_block(self, block: int) -> object:
         return type("B", (), {"number": 1, "timestamp": 1})
 
-    def get_transaction_count(self, address):
+    def get_transaction_count(self, address: str) -> int:
         return 0
 
-    def estimate_gas(self, tx):
+    def estimate_gas(self, tx: dict) -> int:
         return 21000
 
     class account:
         @staticmethod
-        def decode_transaction(tx):
+        def decode_transaction(tx: bytes) -> dict:
             return {}
 
 
 class DummyWeb3:
-    def __init__(self, price):
+    def __init__(self, price: float) -> None:
         self.eth = DummyEth(price)
 
 
 class DummyFeed:
-    def __init__(self, prices):
+    def __init__(self, prices: dict[str, float]) -> None:
         self.prices = prices
         self.web3s = {d: DummyWeb3(p) for d, p in prices.items()}
 
-    def fetch_price(self, pool, domain):
+    def fetch_price(self, pool: object, domain: str) -> PriceData:
         price = self.prices[domain]
         return PriceData(price, pool, 1, 1, 0)
 
 
-def test_capital_lock_blocks_trade(tmp_path):
+def test_capital_lock_blocks_trade(tmp_path) -> None:
     pools = {
         "eth": PoolConfig(
             "0xdeadbeef00000000000000000000000000000000", "ethereum"

--- a/tests/test_ci_prune_score.py
+++ b/tests/test_ci_prune_score.py
@@ -2,12 +2,13 @@
 from ai.mutation_manager import MutationManager
 
 class Dummy:
-    def __init__(self, threshold=0.1):
+    def __init__(self, threshold: float = 0.1) -> None:
         self.t = threshold
-    def evaluate_pnl(self):
+
+    def evaluate_pnl(self) -> float:
         return self.t
 
-def test_batch_pruning_runs():
+def test_batch_pruning_runs() -> None:
     mm = MutationManager({'threshold': 0.1}, num_agents=3)
     mm.spawn_agents(Dummy)
     before = len(mm.agents)


### PR DESCRIPTION
## Summary
- add type ignore for openai import
- remove unused ignore comment in alpha signals
- add type hints across several tests

## Testing
- `pytest -v` *(fails: 11 failed, 98 passed, 2 skipped)*
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/dummy.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683b6febd3cc832ca6dbc907013ffd9c