### PR TITLE
Improve typing and dependency pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ Every PR or batch/module must pass:
 * `scripts/export_state.sh --dry-run`
 * `python ai/audit_agent.py --mode=offline --logs logs/<module>.json`
 
+### Static Type Hygiene
+
+* All functions and classes **must** include type annotations.
+* `mypy --strict` and `ruff check` must report zero errors.
+* Remove unused `# type: ignore` comments and pin dependency versions
+  in `requirements.txt` when updating packages.
+
 **No code is merged without forked-mainnet sim, chaos test, DRP snapshot/restore, and AI/LLM audit.**
 **No promotion or live mutation occurs without explicit founder approval (`FOUNDER_APPROVED=1`) and audit artifact export.**
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Follow this sequence to operate MEV-OG locally.
    pre-commit install
    docker compose build
    docker compose up -d
+   # Python deps pinned in requirements.txt
+   # eth-typing==3.0.0, web3>=6.0.0, openai>=1.0.0
    ```
    Makefile shortcuts are available:
    ```bash

--- a/adapters/alpha_signals.py
+++ b/adapters/alpha_signals.py
@@ -58,7 +58,7 @@ class DuneAnalyticsAdapter(SignalProvider):
     def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
         self.rate.wait()
         try:
-            import requests
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")
@@ -153,7 +153,7 @@ class WhaleAlertAdapter(SignalProvider):
     def fetch(self, *, simulate_failure: str | None = None) -> Dict[str, float]:
         self.rate.wait()
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/adapters/bridge_adapter.py
+++ b/adapters/bridge_adapter.py
@@ -51,7 +51,7 @@ class BridgeAdapter:
     ) -> Dict[str, Any]:
         data = {"from": from_chain, "to": to_chain, "token": token, "amount": amount}
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/adapters/cex_adapter.py
+++ b/adapters/cex_adapter.py
@@ -54,7 +54,7 @@ class CEXAdapter:
     # ------------------------------------------------------------------
     def get_balance(self, *, simulate_failure: str | None = None) -> Dict[str, Any]:
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")
@@ -103,7 +103,7 @@ class CEXAdapter:
     ) -> Dict[str, Any]:
         data = {"side": side, "size": size, "price": price}
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/adapters/dex_adapter.py
+++ b/adapters/dex_adapter.py
@@ -56,7 +56,7 @@ class DEXAdapter:
     ) -> Dict[str, Any]:
         params = {"sellToken": sell_token, "buyToken": buy_token, "amount": amount}
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim network")
@@ -105,7 +105,7 @@ class DEXAdapter:
         simulate_failure: str | None = None,
     ) -> Dict[str, Any]:
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim network")

--- a/adapters/flashloan_adapter.py
+++ b/adapters/flashloan_adapter.py
@@ -50,7 +50,7 @@ class FlashloanAdapter:
     ) -> Dict[str, Any]:
         """Perform the flashloan using an external service."""
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/adapters/pool_scanner.py
+++ b/adapters/pool_scanner.py
@@ -54,7 +54,7 @@ class PoolScanner:
 
     def scan(self, *, simulate_failure: str | None = None) -> List[PoolInfo]:
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")
@@ -100,7 +100,7 @@ class PoolScanner:
     def scan_l3(self, *, simulate_failure: str | None = None) -> List[PoolInfo]:
         """Discover L3/app rollup pools."""
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped]
 
             if simulate_failure == "network":
                 raise RuntimeError("sim net")

--- a/ai/mutator/mutator.py
+++ b/ai/mutator/mutator.py
@@ -52,7 +52,7 @@ class Mutator:
             return json.dumps({"params": {}})
 
         try:
-            import openai as openai_module  # type: ignore  # pragma: no cover - external
+            import openai as openai_module  # pragma: no cover - external
             openai_client = cast(Any, openai_module)
 
             openai_client.api_key = get_secret("OPENAI_API_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-web3
+web3>=6.0.0  # ensures compatibility with eth-typing v3
 pytest
 hexbytes
 requests
@@ -7,4 +7,9 @@ flake8
 flask
 # Flashbots bundle submission
 flashbots
+# dependencies for type hints
+eth-typing==3.0.0  # pinned for web3 compatibility
+eth-account>=0.5.7
+eth-utils>=1.9.5
+openai>=1.0.0  # provides bundled type hints
 # Add any others your code imports


### PR DESCRIPTION
## Summary
- pin web3 and openai dependencies plus required eth packages
- document pinned requirements in README
- add static type hygiene rules in AGENTS.md
- clean up unused ignore comments and keep necessary ones

## Testing
- `mypy --strict .`
- `ruff check .`
- `pytest -v` *(fails: tests failing)*
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/sample_strategy` *(fails: Unknown target)*
- `scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/test.log` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683c979eed90832c9f4100a367846c3c