### PR TITLE
Refactor adapters with session pools & validation

### DIFF
--- a/adapters/pool_scanner.py
+++ b/adapters/pool_scanner.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 import random
-from typing import List
+from typing import List, Dict, Any
+
+import requests
 
 from agents.ops_agent import OpsAgent
 
@@ -44,6 +46,18 @@ class PoolScanner:
         self.ops_agent = ops_agent
         self.fail_threshold = fail_threshold
         self.failures = 0
+        self.session = requests.Session()
+
+    def _validate_pools(self, data: List[Dict[str, Any]]) -> List[PoolInfo]:
+        pools = []
+        for item in data:
+            pool = item.get("pool")
+            domain = item.get("domain")
+            if isinstance(pool, str) and isinstance(domain, str):
+                pools.append(PoolInfo(pool=pool, domain=domain))
+            else:
+                raise ValueError("invalid pool data")
+        return pools
 
     def _alert(self, event: str, err: Exception) -> None:
         self.failures += 1
@@ -51,6 +65,7 @@ class PoolScanner:
         if self.ops_agent:
             self.ops_agent.notify(f"pool_scanner:{event}:{err}")
         if self.failures >= self.fail_threshold:
+            os.environ["OPS_CRITICAL_EVENT"] = "1"
             raise RuntimeError("circuit breaker open")
 
     def scan(self, *, simulate_failure: str | None = None) -> List[PoolInfo]:
@@ -58,27 +73,27 @@ class PoolScanner:
             record_kill_event("pool_scanner.scan")
             return []
         try:
-            import requests  # type: ignore[import-untyped]
-
             if simulate_failure == "network":
                 raise RuntimeError("sim net")
             if simulate_failure == "rpc":
                 raise ValueError("sim rpc")
             if simulate_failure == "data_poison":
-                return [PoolInfo(pool="bad", domain="bad")]
+                bad = [PoolInfo(pool="bad", domain="bad")]
+                self._validate_pools([{"pool": b.pool, "domain": b.domain} for b in bad])
+                return bad
             if simulate_failure == "downtime":
                 raise RuntimeError("sim 503")
 
-            resp = requests.get(f"{self.api_url}/pools", timeout=5)
+            resp = self.session.get(f"{self.api_url}/pools", timeout=5)
             resp.raise_for_status()
             data = resp.json()
-            return [PoolInfo(**d) for d in data]
+            return self._validate_pools(data)
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("scan_fail", exc)
             for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
                     LOG.log("fallback_try", risk_level="low", alt=alt)
-                    resp = requests.get(f"{alt}/pools", timeout=5)
+                    resp = self.session.get(f"{alt}/pools", timeout=5)
                     resp.raise_for_status()
                     LOG.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
@@ -89,7 +104,7 @@ class PoolScanner:
                         failure=simulate_failure or "runtime",
                         fallback="success",
                     )
-                    return [PoolInfo(**d) for d in data]
+                    return self._validate_pools(data)
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
             os.environ["OPS_CRITICAL_EVENT"] = "1"
@@ -107,27 +122,27 @@ class PoolScanner:
             record_kill_event("pool_scanner.scan_l3")
             return []
         try:
-            import requests  # type: ignore[import-untyped]
-
             if simulate_failure == "network":
                 raise RuntimeError("sim net")
             if simulate_failure == "rpc":
                 raise ValueError("sim rpc")
             if simulate_failure == "data_poison":
-                return [PoolInfo(pool="bad", domain="l3")]
+                bad = [PoolInfo(pool="bad", domain="l3")]
+                self._validate_pools([{"pool": b.pool, "domain": b.domain} for b in bad])
+                return bad
             if simulate_failure == "downtime":
                 raise RuntimeError("sim 503")
 
-            resp = requests.get(f"{self.api_url}/l3_pools", timeout=5)
+            resp = self.session.get(f"{self.api_url}/l3_pools", timeout=5)
             resp.raise_for_status()
             data = resp.json()
-            return [PoolInfo(**d) for d in data]
+            return self._validate_pools(data)
         except Exception as exc:  # pragma: no cover - network errors
             self._alert("scan_l3_fail", exc)
             for alt in random.sample(self.alt_api_urls, len(self.alt_api_urls)):
                 try:
                     LOG.log("fallback_try", risk_level="low", alt=alt)
-                    resp = requests.get(f"{alt}/l3_pools", timeout=5)
+                    resp = self.session.get(f"{alt}/l3_pools", timeout=5)
                     resp.raise_for_status()
                     LOG.log("fallback_success", risk_level="low", alt=alt)
                     self.failures = 0
@@ -138,7 +153,7 @@ class PoolScanner:
                         failure=simulate_failure or "runtime",
                         fallback="success",
                     )
-                    return [PoolInfo(**d) for d in data]
+                    return self._validate_pools(data)
                 except Exception as exc2:  # pragma: no cover - network errors
                     self._alert("fallback_fail", exc2)
             os.environ["OPS_CRITICAL_EVENT"] = "1"

--- a/adapters/social_alpha.py
+++ b/adapters/social_alpha.py
@@ -4,17 +4,27 @@ from __future__ import annotations
 
 from typing import List, Dict
 
+import requests
 from core.logger import StructuredLogger
+
+_SESSION = requests.Session()
 
 LOG = StructuredLogger("social_alpha")
 
 
-def scrape_social_keywords(keywords: List[str]) -> List[Dict[str, str]]:
+def scrape_social_keywords(
+    keywords: List[str], *, session: requests.Session | None = None
+) -> List[Dict[str, str]]:
     """Stubbed scanner for Twitter/Discord keywords."""
+    sess = session or _SESSION
+    # placeholder network call using session for future expansion
+    _ = sess
     results = [
         {"domain": "arbitrum", "pool": "0xb3f8e4262c5bfcc0a304143cfb33c7a9a64e0fe0"},
-        # Base ETH/USDC pool on the Optimism superchain
         {"domain": "l3_superchain", "pool": "0x91a502c978a60c206cd1e904af73607f99e2c1b2"},
     ]
+    for r in results:
+        if not isinstance(r.get("pool"), str) or not isinstance(r.get("domain"), str):
+            raise ValueError("invalid social data")
     LOG.log("social_alpha_scan", keywords=keywords, found=len(results))
     return results


### PR DESCRIPTION
## Summary
- use persistent `requests.Session` for DEX/CEX/bridge/pool scanners and social alpha
- validate adapter responses and raise on invalid data
- open circuit breaker on repeated failures and set `OPS_CRITICAL_EVENT`
- add regression test for bad data handling

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: No module named 'strategies')*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/dex_adapter.json` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_683d17792bbc832c819ab1ec0043170e