### PR TITLE
Add AI/LLM safety doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ MEV-OG is an AI-native, adversarial crypto trading system built to compound $5K 
 - [Mutation Workflow](#mutation-workflow)
 - [DRP Recovery](#drp-recovery)
 - [CI/CD](#cicd--canary-deployment)
+- [AI/LLM Safety](docs/AI_LLM_SAFETY.md)
 
 ## System Architecture
 

--- a/docs/AI_LLM_SAFETY.md
+++ b/docs/AI_LLM_SAFETY.md
@@ -1,0 +1,19 @@
+# AI/LLM Safety—Sandbox, Gating, and Mutation Audit
+
+This document summarizes the mandatory controls for safe AI/LLM driven mutation and promotion within the project.
+
+## Scope
+- **Sandbox Execution**: Never evaluate or execute LLM or auto‑generated code outside a secure, auditable sandbox.
+- **Founder/Multi-Sig Gating**: All mutation, audit, and promotion steps must be explicitly approved by the founder or designated multi‑sig holders. Every approval must be logged with a `TRACE_ID`.
+- **No Placebo Logic**: Remove all placeholder or stub implementations in AI scoring, mutation, and audit modules. Replace them with real, testable logic that emits structured logs.
+- **Structured Logs**: Every event must be timestamped and formatted for audit agents. Logs are written to `logs/<module>.json` and errors to `logs/errors.log`.
+- **Mutation Tests**: Tests include malicious code injection attempts, blocked AI mutation scenarios, and enforcement of founder gating. These tests must run in CI before any promotion.
+
+## Promotion Workflow
+1. Run fork simulations and unit tests.
+2. Execute `ai/audit_agent.py` in offline mode.
+3. Capture a DRP snapshot via `scripts/export_state.sh`.
+4. Obtain founder approval (`FOUNDER_TOKEN`) and log the `TRACE_ID`.
+5. Promote the strategy using `ai/promote.py`.
+
+All steps must be logged and traceable. Promotion cannot proceed if any check fails or if founder approval is missing.


### PR DESCRIPTION
## Summary
- document sandbox and founder gating requirements
- reference the new safety guide from README

## Testing
- `pytest -v` *(fails: 11 failed, 101 passed, 5 skipped)*
- `ruff check`
- `mypy --strict` *(fails: 8 errors)*
- `foundry test` *(command not found)*
- `bash scripts/export_state.sh --dry-run`
- `python ai/audit_agent.py --mode=offline --logs logs/log.txt`


------
https://chatgpt.com/codex/tasks/task_e_683f7ac84c54832c86c681e012af4da5