### PR TITLE
Enforce Python 3.11 usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
           python-version: '3.11'
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt mypy ruff
+          python3.11 -m pip install --upgrade pip
+          python3.11 -m pip install -r requirements.txt mypy ruff
       - name: Lint
         run: ruff check .
       - name: Type check
@@ -36,9 +36,9 @@ jobs:
       - name: DRP dry run
         run: bash scripts/export_state.sh --dry-run
       - name: Offline audit
-        run: python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+        run: python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
       - name: Chaos drill
-        run: python infra/sim_harness/chaos_drill.py
+        run: python3.11 infra/sim_harness/chaos_drill.py
       - name: Tag canary
         run: |
           TAG="canary-${{ github.sha }}-$(date +%Y%m%d)"
@@ -50,9 +50,9 @@ jobs:
           pytest -v
           bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
           bash scripts/export_state.sh --dry-run
-          python ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+          python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
       - name: Check gates
-        run: python agents/check_gates.py
+        run: python3.11 agents/check_gates.py
       - name: Promote
         if: env.FOUNDER_TOKEN != ''
         run: echo "Founder approval received. Ready for production."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@ Certainly! Below is the **fully augmented AGENTS.md**, enhanced with the missing
 
 This version is **safe to integrate without breaking current flows**, as it only adds explicit compliance, documentation, and enforcement clarity, **no logic or code changes**.
 
+**Python 3.11 Required**
+
+You must use Python 3.11 and activate your virtual environment before running any `python` or `pip` command.
+
 ---
 
 # AGENTS.md — Codex & LLM Instructions for MEV-OG
@@ -84,7 +88,7 @@ Every PR or batch/module must pass:
 * `foundry test` (or documented alternate if missing)
 * `scripts/simulate_fork.sh --target=strategies/<module>`
 * `scripts/export_state.sh --dry-run`
-* `python ai/audit_agent.py --mode=offline --logs logs/<module>.json`
+* `python3.11 ai/audit_agent.py --mode=offline --logs logs/<module>.json`
 
 ### Static Type Hygiene
 
@@ -109,7 +113,7 @@ Every PR or batch/module must pass:
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 
 ### cross\_domain\_arb
 
@@ -120,7 +124,7 @@ Every PR or batch/module must pass:
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 * Env vars:
   `CROSS_ARB_STATE_PRE`, `CROSS_ARB_STATE_POST`, `CROSS_ARB_TX_PRE`, `CROSS_ARB_TX_POST`, `CROSS_ARB_LOG`
 
@@ -133,7 +137,7 @@ Every PR or batch/module must pass:
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 
 ### l3\_sequencer\_mev
 
@@ -144,7 +148,7 @@ Every PR or batch/module must pass:
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 
 ### nft\_liquidation
 
@@ -155,12 +159,12 @@ Every PR or batch/module must pass:
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 
 ### chaos_drill
 
 * Run harness:
-  `python infra/sim_harness/chaos_drill.py`
+  `python3.11 infra/sim_harness/chaos_drill.py`
 * Validate:
   `pytest tests/test_chaos_drill.py`
 * Results are written to `logs/chaos_drill.json` with per-adapter failure counts in `logs/drill_metrics.json`.
@@ -171,13 +175,13 @@ Every PR or batch/module must pass:
 * Run targeted adapter chaos tests:
   `pytest tests/test_adapters_chaos.py`
 * Manual simulation:
-  `python tests/test_adapters_chaos.py --simulate bridge_downtime`
+  `python3.11 tests/test_adapters_chaos.py --simulate bridge_downtime`
 * Expect `fallback_success` events in module logs and OpsAgent alerts for each failure.
 
 ### chaos_scheduler
 
 * Run scheduler:
-  `CHAOS_ONCE=1 python infra/sim_harness/chaos_scheduler.py`
+  `CHAOS_ONCE=1 python3.11 infra/sim_harness/chaos_scheduler.py`
 * Configure via ENV:
   `CHAOS_INTERVAL`, `CHAOS_ADAPTERS`, `CHAOS_MODES`, `CHAOS_SCHED_LOG`.
 * Scheduler logs to `logs/chaos_scheduler.json` and updates `logs/drill_metrics.json`.
@@ -185,7 +189,7 @@ Every PR or batch/module must pass:
 ### OpsAgent & CapitalLock Runbook
 
 * Start OpsAgent:
-  `python -m agents.ops_agent` (health checks configured in config)
+  `python3.11 -m agents.ops_agent` (health checks configured in config)
 * Use `scripts/batch_ops.py` to promote, pause, or rollback strategies.
 * CapitalLock state is shared via `agents.agent_registry` and unpaused **only when founder provides a valid `FOUNDER_TOKEN` and calls unlock with a unique `TRACE_ID`**.
 * Example strategy integration:
@@ -205,7 +209,7 @@ strat = Strategy(..., capital_lock=lock)
 * Rollback:
   `bash scripts/rollback.sh --archive=<path>`
 * Mutation cycle:
-  `python ai/mutator/main.py --logs-dir logs`
+  `python3.11 ai/mutator/main.py --logs-dir logs`
 
 ### Gas/Latency Runbook
 
@@ -215,7 +219,7 @@ strat = Strategy(..., capital_lock=lock)
 - Bundle latency is returned for metrics and log entry enrichment.
 ### Strategy Review & Pruning
 
-- Run `python -m core.strategy_scoreboard` or call `StrategyScoreboard.prune_and_score()` after each trading loop.
+- Run `python3.11 -m core.strategy_scoreboard` or call `StrategyScoreboard.prune_and_score()` after each trading loop.
 - Adapters for Dune Analytics, Whale Alert and Coinbase WebSocket are enabled via environment variables. Review `logs/scoreboard.json` for scores blended with external signals.
 - Multi-sig founder approval (`FOUNDER_TOKEN`) is required for pruning and promotion. Alerts and metrics are dispatched via `OpsAgent.notify` and Prometheus.
 - Every prune/promote/mutation event is recorded in `logs/mutation_log.json` using the current `TRACE_ID`.
@@ -225,10 +229,10 @@ strat = Strategy(..., capital_lock=lock)
 
 | Command | Purpose |
 |---------|---------|
-| `python ai/promote.py` | Promote tested strategies into the active set. Requires `FOUNDER_TOKEN` and `TRACE_ID`. |
-| `python scripts/batch_ops.py promote <strat>` | Batch promote one or more strategies. |
-| `python scripts/batch_ops.py pause <strat>` | Move a live strategy to the paused directory. |
-| `python scripts/batch_ops.py rollback <strat>` | Restore a strategy from audit logs. |
+| `python3.11 ai/promote.py` | Promote tested strategies into the active set. Requires `FOUNDER_TOKEN` and `TRACE_ID`. |
+| `python3.11 scripts/batch_ops.py promote <strat>` | Batch promote one or more strategies. |
+| `python3.11 scripts/batch_ops.py pause <strat>` | Move a live strategy to the paused directory. |
+| `python3.11 scripts/batch_ops.py rollback <strat>` | Restore a strategy from audit logs. |
 | `bash scripts/kill_switch.sh` | Toggle the global kill switch. |
 | `bash scripts/export_state.sh` | Export logs and state into `$EXPORT_DIR`. |
 | `bash scripts/rollback.sh --archive=<file>` | Restore from a DRP archive. |

--- a/AGENTS/README.md
+++ b/AGENTS/README.md
@@ -2,6 +2,10 @@
 
 This document lists environment variables and Python packages used by automation agents and test harnesses.
 
+**Python 3.11 Required**
+
+You must use Python 3.11 and activate your virtual environment before running any `python` or `pip` command.
+
 ## New Variables
 
 - `FLASHBOTS_AUTH_KEY` – private key used to sign Flashbots or SUAVE bundles.
@@ -9,4 +13,4 @@ This document lists environment variables and Python packages used by automation
 
 ## Dependencies
 
-The `flashbots` Python package is required for bundle submission via Web3. Install via `pip install -r requirements.txt`.
+The `flashbots` Python package is required for bundle submission via Web3. Install via `python3.11 -m pip install -r requirements.txt`.

--- a/Dockerfile.pool_scanner
+++ b/Dockerfile.pool_scanner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ simulate:
 bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
 
 mutate:
-python ai/mutator/main.py
+python3.11 ai/mutator/main.py
 
 export:
 bash scripts/export_state.sh
 
 promote:
-FOUNDER_TOKEN=dummy python ai/promote.py
+FOUNDER_TOKEN=dummy python3.11 ai/promote.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ MEV-OG is an AI-native, adversarial crypto trading system built to compound $5K 
 > NOTE: All operational law, workflow, and validation in this file derive from PROJECT_BIBLE.md.  
 > Any contradiction: PROJECT_BIBLE.md is the source of truth.
 
+**Python 3.11 Required**
+
+You must use Python 3.11 and activate your virtual environment before running any `python` or `pip` command.
+
 
 ## Table of Contents
 
@@ -115,13 +119,13 @@ Follow this sequence to operate MEV-OG locally.
    ```
 7. **Execute the mutation workflow**
    ```bash
-   python ai/mutator/main.py
+   python3.11 ai/mutator/main.py
    # or
    make mutate
    ```
 8. **Promote when checks pass**
    ```bash
-   python ai/promote.py
+   python3.11 ai/promote.py
    # or
    make promote
    ```
@@ -140,7 +144,7 @@ Follow this sequence to operate MEV-OG locally.
 
 Start the metrics endpoint with:
 ```bash
-python -m core.metrics --port $METRICS_PORT
+python3.11 -m core.metrics --port $METRICS_PORT
 ```
 and point Prometheus to `http://localhost:$METRICS_PORT/metrics` for monitoring.
 If `METRICS_TOKEN` is set, include `Authorization: Bearer $METRICS_TOKEN` in
@@ -273,11 +277,11 @@ the values used in tests and the simulation harness:
 
 ```bash
 # Start metrics server
-python -m core.metrics &
+python3.11 -m core.metrics &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
 # Run mutation cycle (updates threshold)
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot
 bash scripts/export_state.sh
 ```
@@ -304,11 +308,11 @@ All logs and DRP exports are sanitized with `make_json_safe()` so that every ent
 
 ```bash
 # Start metrics server
-python -m core.metrics --port $METRICS_PORT &
+python3.11 -m core.metrics --port $METRICS_PORT &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot
 # Run a mutation and audit cycle
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot and rollback if needed
 bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
@@ -324,11 +328,11 @@ Paths default under `logs/` or `state/` unless overridden.
 
 ```bash
 # Start metrics server
-python -m core.metrics --port $METRICS_PORT &
+python3.11 -m core.metrics --port $METRICS_PORT &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/l3_app_rollup_mev
 # Run a mutation and audit cycle
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot and rollback if needed
 bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
@@ -344,11 +348,11 @@ Paths default under `logs/` or `state/` unless overridden.
 
 ```bash
 # Start metrics server
-python -m core.metrics --port $METRICS_PORT &
+python3.11 -m core.metrics --port $METRICS_PORT &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/l3_sequencer_mev
 # Run a mutation and audit cycle
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot and rollback if needed
 bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
@@ -364,11 +368,11 @@ Paths default under `logs/` or `state/` unless overridden.
 
 ```bash
 # Start metrics server
-python -m core.metrics --port $METRICS_PORT &
+python3.11 -m core.metrics --port $METRICS_PORT &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/nft_liquidation
 # Run a mutation and audit cycle
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot and rollback if needed
 bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
@@ -384,11 +388,11 @@ Paths default under `logs/` or `state/` unless overridden.
 
 ```bash
 # Start metrics server
-python -m core.metrics --port $METRICS_PORT &
+python3.11 -m core.metrics --port $METRICS_PORT &
 # Run fork simulation
 bash scripts/simulate_fork.sh --target=strategies/rwa_settlement
 # Run a mutation and audit cycle
-python ai/mutator/main.py --logs-dir logs
+python3.11 ai/mutator/main.py --logs-dir logs
 # Export DRP snapshot and rollback if needed
 bash scripts/export_state.sh
 bash scripts/rollback.sh --archive=<exported-archive>
@@ -429,8 +433,8 @@ error log `logs/errors.log`. Metrics use the global `/metrics` endpoint.
 Run automated mutation cycles and promote only after all checks pass.
 
 ```bash
-python ai/mutator/main.py
-python ai/promote.py  # requires FOUNDER_TOKEN
+python3.11 ai/mutator/main.py
+python3.11 ai/promote.py  # requires FOUNDER_TOKEN
 ```
 
 main
@@ -478,7 +482,7 @@ the flag and log paths.
 Run the automated chaos/disaster recovery drill harness:
 
 ```bash
-python infra/sim_harness/chaos_drill.py
+python3.11 infra/sim_harness/chaos_drill.py
 ```
 
 This triggers the kill switch, pauses capital via OpsAgent, simulates a lost agent, and forces failure across every supported adapter (DEX, bridge, CEX, flashloan, intent, sequencer and node). After each event the drill exports state with `scripts/export_state.sh`, restores it with `scripts/rollback.sh`, and scans all logs/archives for secrets or PII. Any secret causes an immediate failure. Export archives are stored in `export/`, drill logs in `logs/chaos_drill.json`, and per-module failure counts in `logs/drill_metrics.json`.
@@ -500,7 +504,7 @@ pytest tests/test_adapters_chaos.py
 Manual simulation example:
 
 ```bash
-python tests/test_adapters_chaos.py --simulate bridge_downtime
+python3.11 tests/test_adapters_chaos.py --simulate bridge_downtime
 ```
 
 During a network outage the logs include entries like:
@@ -516,7 +520,7 @@ Metrics from the chaos run are written to `logs/drill_metrics.json` and OpsAgent
 Run scheduled chaos injections that randomly target adapters and failure modes:
 
 ```bash
-CHAOS_ONCE=1 python infra/sim_harness/chaos_scheduler.py
+CHAOS_ONCE=1 python3.11 infra/sim_harness/chaos_scheduler.py
 ```
 
 Set `CHAOS_INTERVAL` (seconds), `CHAOS_ADAPTERS`, and `CHAOS_MODES` to control frequency and scope. Scheduler logs to `logs/chaos_scheduler.json` and updates `logs/drill_metrics.json` on each run.
@@ -550,7 +554,7 @@ All bundle-based strategies share a common gas and latency tuning flow.
 Example:
 
 ```bash
-PRIORITY_FEE_GWEI=3 python -m core.orchestrator --config=config.yaml --dry-run
+PRIORITY_FEE_GWEI=3 python3.11 -m core.orchestrator --config=config.yaml --dry-run
 ```
 
 ## Strategy Orchestrator
@@ -559,8 +563,8 @@ PRIORITY_FEE_GWEI=3 python -m core.orchestrator --config=config.yaml --dry-run
 enforces kill switch, capital lock and founder approval on every iteration.
 
 ```bash
-python -m core.orchestrator --config=config.yaml --dry-run   # single cycle
-python -m core.orchestrator --config=config.yaml --live      # continuous
+python3.11 -m core.orchestrator --config=config.yaml --dry-run   # single cycle
+python3.11 -m core.orchestrator --config=config.yaml --live      # continuous
 ```
 
 Use `--health` to run only OpsAgent checks. Live mode requires
@@ -581,7 +585,7 @@ See the example call at the end of this README for a typical promotion command.
 Example usage:
 
 ```bash
-python scripts/batch_ops.py promote cross_rollup_superbot --source-dir staging --dest-dir active
+python3.11 scripts/batch_ops.py promote cross_rollup_superbot --source-dir staging --dest-dir active
 ```
 ## Strategy Review & Pruning
 
@@ -595,9 +599,9 @@ action logs to `logs/wallet_ops.json` and snapshots state via
 `scripts/export_state.sh` before and after execution.
 
 ```
-python scripts/wallet_ops.py fund --from 0xabc --to 0xdef --amount 1 --dry-run
-python scripts/wallet_ops.py withdraw-all --from 0xhot --to 0xbank
-python scripts/wallet_ops.py drain-to-cold --from 0xhot --to 0xcold
+python3.11 scripts/wallet_ops.py fund --from 0xabc --to 0xdef --amount 1 --dry-run
+python3.11 scripts/wallet_ops.py withdraw-all --from 0xhot --to 0xbank
+python3.11 scripts/wallet_ops.py drain-to-cold --from 0xhot --to 0xcold
 ```
 
 Set `FOUNDER_TOKEN` and export a unique `TRACE_ID` or confirm interactively
@@ -617,7 +621,7 @@ when prompted. On failure the script aborts and logs the error.
 Dry-run example:
 
 ```bash
-python ai/mutator/main.py --logs-dir logs --dry-run
+python3.11 ai/mutator/main.py --logs-dir logs --dry-run
 ```
 
 After verifying results, remove `--dry-run` and set `mode: live` in
@@ -628,8 +632,8 @@ After verifying results, remove `--dry-run` and set `mode: live` in
 Use `scripts/wallet_ops.py` to safely fund or drain wallets.
 
 ```bash
-python scripts/wallet_ops.py deposit 1.0   # fund 1 ETH
-python scripts/wallet_ops.py withdraw 0.5  # withdraw 0.5 ETH
+python3.11 scripts/wallet_ops.py deposit 1.0   # fund 1 ETH
+python3.11 scripts/wallet_ops.py withdraw 0.5  # withdraw 0.5 ETH
 ```
 
 Actions append to `logs/wallet_ops.log` for auditing.
@@ -641,16 +645,16 @@ Actions append to `logs/wallet_ops.log` for auditing.
 3. Copy `config.example.yaml` to `config.yaml`
 4. Run `pytest -v` and `foundry test`
 5. `bash scripts/simulate_fork.sh --target=strategies/<module>`
-6. `python ai/mutator/main.py --dry-run`
+6. `python3.11 ai/mutator/main.py --dry-run`
 7. Review `logs/errors.log` and DRP archive
-8. Set `FOUNDER_TOKEN` and export a `TRACE_ID` then run `python ai/mutator/main.py --mode live`
+8. Set `FOUNDER_TOKEN` and export a `TRACE_ID` then run `python3.11 ai/mutator/main.py --mode live`
 9. Check metrics at `http://localhost:$METRICS_PORT/metrics`
 10. Drain funds with `wallet_ops.py` if needed
 
 ## Troubleshooting / FAQ
 
 - **RPC failures:** confirm endpoints in `config.yaml` and ensure nodes are live.
-- **Metrics missing:** run `python -m core.metrics --port $METRICS_PORT`.
+- **Metrics missing:** run `python3.11 -m core.metrics --port $METRICS_PORT`.
 - **Promotion blocked:** ensure `FOUNDER_TOKEN` is valid, a `TRACE_ID` is set and read `logs/errors.log`.
 - **Rollback:** `bash scripts/rollback.sh --archive=<archive>`.
 

--- a/adapters/pool_scanner_service.py
+++ b/adapters/pool_scanner_service.py
@@ -24,7 +24,7 @@ GET /metrics     -- Prometheus metrics if ``ENABLE_METRICS=1``.
 
 Usage
 =====
-Run directly via ``python -m adapters.pool_scanner_service`` or build the
+Run directly via ``python3.11 -m adapters.pool_scanner_service`` or build the
 provided Dockerfile (see repo ``docker-compose.yml`` example service block).
 
 """

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,6 +2,10 @@
 
 This quick-start guide summarizes how to set up and run the project. For detailed policies and runbooks, see [AGENTS.md](../AGENTS.md) and [PROJECT_BIBLE.md](../PROJECT_BIBLE.md).
 
+**Python 3.11 Required**
+
+You must use Python 3.11 and activate your virtual environment before running any `python` or `pip` command.
+
 ## 1. Install Dependencies
 
 ```bash
@@ -48,7 +52,7 @@ make test
 Run a mutation cycle if simulations succeed:
 
 ```bash
-python ai/mutator/main.py
+python3.11 ai/mutator/main.py
 make mutate
 ```
 
@@ -57,9 +61,9 @@ make mutate
 Set `FOUNDER_TOKEN` to allow promotion and then execute:
 
 ```bash
-python ai/promote.py            # single promotion
+python3.11 ai/promote.py            # single promotion
 # or
-python scripts/batch_ops.py promote <strategy> --source-dir staging --dest-dir active
+python3.11 scripts/batch_ops.py promote <strategy> --source-dir staging --dest-dir active
 make promote
 ```
 
@@ -90,7 +94,7 @@ Use `scripts/kill_switch.sh` to toggle the system kill switch. Start the metrics
 server for Prometheus scraping with:
 
 ```bash
-python -m core.metrics --port $METRICS_PORT
+python3.11 -m core.metrics --port $METRICS_PORT
 ```
 If you set `METRICS_TOKEN`, include the header
 `Authorization: Bearer $METRICS_TOKEN` when scraping.
@@ -101,13 +105,13 @@ Start all enabled strategies using the unified orchestrator. Use dry-run mode
 first to verify configuration:
 
 ```bash
-python -m core.orchestrator --config=config.yaml --dry-run
+python3.11 -m core.orchestrator --config=config.yaml --dry-run
 ```
 
 For continuous live execution run:
 
 ```bash
-python -m core.orchestrator --config=config.yaml --live
+python3.11 -m core.orchestrator --config=config.yaml --live
 ```
 
 Live mode requires a valid `FOUNDER_TOKEN`. Use `--health` for an on-demand health
@@ -119,9 +123,9 @@ check without executing strategies.
 requires founder confirmation and logs to `logs/wallet_ops.json`.
 
 ```bash
-python scripts/wallet_ops.py fund --from 0xabc --to 0xdef --amount 1
-python scripts/wallet_ops.py withdraw-all --from 0xhot --to 0xbank
-python scripts/wallet_ops.py drain-to-cold --from 0xhot --to 0xcold
+python3.11 scripts/wallet_ops.py fund --from 0xabc --to 0xdef --amount 1
+python3.11 scripts/wallet_ops.py withdraw-all --from 0xhot --to 0xbank
+python3.11 scripts/wallet_ops.py drain-to-cold --from 0xhot --to 0xcold
 ```
 
 Use `--dry-run` to simulate without sending a transaction. State snapshots are
@@ -142,7 +146,7 @@ list of options. The most important flags are:
 Example dry-run:
 
 ```bash
-python ai/mutator/main.py --logs-dir logs --dry-run
+python3.11 ai/mutator/main.py --logs-dir logs --dry-run
 ```
 
 If the run completes with no errors you can promote to live trading by removing
@@ -160,8 +164,8 @@ bash scripts/rollback.sh --archive=<exported-archive>
 ### Kill/Pause/Rollback flows
 
 * **Kill switch:** `bash scripts/kill_switch.sh` toggles trading halt.
-* **Pause strategy:** `python scripts/batch_ops.py pause <strategy>`.
-* **Rollback:** `python scripts/batch_ops.py rollback <strategy>` or use the DRP
+* **Pause strategy:** `python3.11 scripts/batch_ops.py pause <strategy>`.
+* **Rollback:** `python3.11 scripts/batch_ops.py rollback <strategy>` or use the DRP
   archive as shown above.
 
 ### Troubleshooting

--- a/infra/sim_harness/chaos_drill.py
+++ b/infra/sim_harness/chaos_drill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.11
 """Automated chaos/disaster recovery drill harness."""
 
 from __future__ import annotations

--- a/infra/sim_harness/chaos_scheduler.py
+++ b/infra/sim_harness/chaos_scheduler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.11
 """Scheduled chaos injection harness."""
 
 from __future__ import annotations

--- a/scripts/batch_ops.py
+++ b/scripts/batch_ops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.11
 """Batch operations for promoting, pausing, or rolling back strategies."""
 
 from __future__ import annotations

--- a/scripts/replay_arms_race.py
+++ b/scripts/replay_arms_race.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.11
 """Replay historical MEV transactions for benchmarking."""
 from __future__ import annotations
 

--- a/scripts/wallet_ops.py
+++ b/scripts/wallet_ops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.11
 """Founder-gated wallet operations: fund, withdraw-all, drain-to-cold."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- pin pool scanner image to python:3.11-slim
- require Python 3.11 in docs and readmes
- update Makefile and CI to call python3.11 explicitly
- fix shebangs to python3.11

## Testing
- `python3.11 -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement web3==6.11.4)*
- `pytest -v` *(fails: 11 failed, 101 passed, 5 skipped)*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: No module named 'strategies')*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: No module named 'core')*
- `docker build -t mev-og-test -f Dockerfile .` *(fails: docker: command not found)*
- `docker build -t poolscanner -f Dockerfile.pool_scanner .` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f80fd16e0832cbcd47a40b56c22a4