### PR TITLE
Fix request mocks and founder token for tests

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,15 +1,17 @@
 """Adapters package for external APIs."""
 
 # Lazy imports to avoid optional dependency issues at package import time.
-BridgeAdapter = None
-CEXAdapter = None
-DEXAdapter = None
-FlashloanAdapter = None
-PoolScanner = None
-PoolInfo = None
-DuneAnalyticsAdapter = None
-WhaleAlertAdapter = None
-CoinbaseWebSocketAdapter = None
+from typing import Any
+
+BridgeAdapter: Any = None
+CEXAdapter: Any = None
+DEXAdapter: Any = None
+FlashloanAdapter: Any = None
+PoolScanner: Any = None
+PoolInfo: Any = None
+DuneAnalyticsAdapter: Any = None
+WhaleAlertAdapter: Any = None
+CoinbaseWebSocketAdapter: Any = None
 
 __all__ = [
     "BridgeAdapter",

--- a/tests/test_adapters_chaos.py
+++ b/tests/test_adapters_chaos.py
@@ -87,10 +87,17 @@ def _setup_requests(
             return _dummy_response(data or {"ok": True})
         raise RuntimeError("fail")
 
+    class _Session:
+        def get(self, url: str, *a: Any, **k: Any) -> Any:
+            return fake_get(url, *a, **k)
+
+        def post(self, url: str, *a: Any, **k: Any) -> Any:
+            return fake_post(url, *a, **k)
+
     monkeypatch.setitem(
         sys.modules,
         "requests",
-        SimpleNamespace(get=fake_get, post=fake_post),
+        SimpleNamespace(get=fake_get, post=fake_post, Session=lambda: _Session()),
     )
 
 
@@ -114,10 +121,16 @@ def test_multi_endpoint_fallback(monkeypatch, log_env):
             return _dummy_response({"ok": True})
         raise RuntimeError("fail")
 
+    class _Session:
+        def get(self, url: str, *a: Any, **k: Any) -> Any:
+            return fake_get(url, *a, **k)
+
+        post = get
+
     monkeypatch.setitem(
         sys.modules,
         "requests",
-        SimpleNamespace(get=fake_get, post=fake_get),
+        SimpleNamespace(get=fake_get, post=fake_get, Session=lambda: _Session()),
     )
     ops = DummyOps()
     DEXAdapter = _load("dex_adapter", "adapters/dex_adapter.py").DEXAdapter

--- a/tests/test_pool_scanner_service.py
+++ b/tests/test_pool_scanner_service.py
@@ -10,13 +10,30 @@ def test_health_endpoint() -> None:
     assert data["status"] == "ok"
 
 
-def test_pools_endpoint_filter() -> None:
-    app = create_app()
+def test_pools_endpoint_filter(monkeypatch) -> None:
+    from adapters import pool_scanner_service
+
+    monkeypatch.setattr(
+        pool_scanner_service,
+        "MOCK_POOLS",
+        [
+            {
+                "address": "0x1",
+                "token0": "WETH",
+                "token1": "USDC",
+                "fee": 0.0,
+                "liquidity": 1.0,
+                "tick": 0,
+                "extra": {"dex": "uniswap", "chain": "ethereum"},
+            }
+        ],
+    )
+    app = pool_scanner_service.create_app()
     client = app.test_client()
     resp = client.get("/pools?dex=uniswap&chain=ethereum")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data
+    assert data and isinstance(data, list)
     assert all(p["extra"]["chain"] == "ethereum" for p in data)
 
 

--- a/tests/test_wallet_ops.py
+++ b/tests/test_wallet_ops.py
@@ -28,7 +28,7 @@ def test_fund_dry_run(tmp_path: Path) -> None:
     env = os.environ.copy()
     env.update(
         {
-            "FOUNDER_TOKEN": "x:9999999999",
+            "FOUNDER_TOKEN": "wallet_ops:9999999999",
             "WALLET_OPS_LOG": str(tmp_path / "wallet.json"),
             "EXPORT_LOG_FILE": str(tmp_path / "export.json"),
             "EXPORT_DIR": str(tmp_path / "export"),
@@ -91,7 +91,7 @@ def test_tx_fail(tmp_path: Path) -> None:
     env = os.environ.copy()
     env.update(
         {
-            "FOUNDER_TOKEN": "x:9999999999",
+            "FOUNDER_TOKEN": "wallet_ops:9999999999",
             "WALLET_OPS_LOG": str(tmp_path / "wallet.json"),
             "EXPORT_LOG_FILE": str(tmp_path / "export.json"),
             "EXPORT_DIR": str(tmp_path / "export"),
@@ -122,7 +122,7 @@ def test_insufficient_funds(tmp_path: Path) -> None:
     env = os.environ.copy()
     env.update(
         {
-            "FOUNDER_TOKEN": "x:9999999999",
+            "FOUNDER_TOKEN": "wallet_ops:9999999999",
             "WALLET_OPS_LOG": str(tmp_path / "wallet.json"),
             "EXPORT_LOG_FILE": str(tmp_path / "export.json"),
             "EXPORT_DIR": str(tmp_path / "export"),


### PR DESCRIPTION
## Summary
- type request adapters as Any in `adapters/__init__.py`
- provide fake `Session` in chaos adapter tests
- mock `requests` before importing cross domain arb in `test_new_modules.py`
- patch mock pool data in pool scanner service tests
- use correct founder token for wallet ops tests

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/wallet_ops.json`

------
https://chatgpt.com/codex/tasks/task_e_683f9e6e25e8832cb2af9fb07d08990f