### PR TITLE
Extend metrics tracking

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -81,6 +81,9 @@ def log_error(
     with path.open("a") as fh:
         fh.write(json.dumps(make_json_safe(entry)) + "\n")
 
+    from core import metrics as _metrics
+    _metrics.record_error()
+
 
 _HOOKS: List[Callable[[Dict[str, Any]], None]] = []
 _ALERT_WEBHOOKS = [w for w in os.getenv("OPS_ALERT_WEBHOOK", "").split(",") if w]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,7 +12,18 @@ opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 def test_metrics_server(tmp_path):
     srv = metrics.MetricsServer(port=0)
     srv.start()
-    metrics._METRICS.update({"opportunities": 0, "fails": 0, "pnl": 0.0, "spreads": [], "latencies": [], "alert_count": 0})
+    metrics._METRICS.update({
+        "opportunities": 0,
+        "fails": 0,
+        "pnl": 0.0,
+        "spreads": [],
+        "latencies": [],
+        "alert_count": 0,
+        "opportunities_found": 0,
+        "arb_profit": 0.0,
+        "arb_latency": [],
+        "error_count": 0,
+    })
 
     metrics.record_opportunity(0.1, 5.0, 0.5)
     metrics.record_fail()
@@ -26,6 +37,9 @@ def test_metrics_server(tmp_path):
     assert "opportunities_total 1" in data
     assert "fails_total 1" in data
     assert "alert_count 1" in data
+    assert "opportunities_found_total 1" in data
+    assert "arb_profit_total 5.0" in data
+    assert "error_count 1" in data
 
 
 def _start_server_with_token(monkeypatch, token):
@@ -61,3 +75,13 @@ def test_metrics_unauthorized(monkeypatch):
         raise AssertionError("expected 401")
     finally:
         srv.stop()
+
+
+def test_error_count(monkeypatch, tmp_path):
+    from core.logger import log_error
+
+    err_file = tmp_path / "err.log"
+    monkeypatch.setenv("ERROR_LOG_FILE", str(err_file))
+    metrics._METRICS["error_count"] = 0
+    log_error("test", "boom")
+    assert metrics._METRICS["error_count"] == 1


### PR DESCRIPTION
## Summary
- expand metrics dictionary with arb and error statistics
- track arb metrics in `record_opportunity`
- record errors via `record_error` and hook into `record_fail` and logger
- expose new metrics from the HTTP server
- update tests for extended metrics and add error counter test

## Testing
- `ruff check .`
- `mypy --strict` *(fails: ModuleNotFoundError and unused ignore comments)*
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845da73f81c832c9cd09bd37633816a