### PR TITLE
Add latency metrics recording

### DIFF
--- a/agents/ops_agent.py
+++ b/agents/ops_agent.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import os
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from core.logger import StructuredLogger
-
-try:  # optional metrics; tests may stub out core
-    from core import metrics as metrics_module
-except Exception:  # pragma: no cover - optional dependency
-    metrics_module = None
 from .agent_registry import set_value
+
+metrics_module: Optional[Any] = None
+try:  # optional metrics; tests may stub out core
+    from core import metrics as _metrics
+    metrics_module = _metrics
+except Exception:  # pragma: no cover - optional dependency
+    pass
 
 LOGGER = StructuredLogger("ops_agent")
 

--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -546,9 +546,12 @@ class CrossDomainArb(BaseStrategy):
             self.tx_builder.snapshot(tx_post)
             self.snapshot(post)
 
+            metrics.record_opportunity(float(opp["spread"]), profit, latency)
+
             self.capital_lock.record_trade(profit)
 
-            self.record_result(True, profit)
+            self.performance.record(True, profit)
+            self._check_prune()
 
             for label, data in price_data.items():
                 self._record(


### PR DESCRIPTION
## Summary
- record spread/profit/latency in CrossDomainArb strategy
- fix mypy typing for optional metrics in ops agent

## Testing
- `ruff check strategies/cross_domain_arb/strategy.py agents/ops_agent.py`
- `mypy --strict strategies/cross_domain_arb/strategy.py agents/ops_agent.py`
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845db959070832c8d0c391649aa4075