### PR TITLE
Add startup script for metrics and update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ COPY . .
 
 USER mevog
 # Default command can be overridden at runtime
-CMD ["python", "-m", "core.orchestrator", "--config=config.yaml", "--dry-run"]
+COPY scripts/start_with_metrics.sh scripts/start_with_metrics.sh
+
+CMD ["/bin/bash", "scripts/start_with_metrics.sh", "--dry-run"]

--- a/scripts/start_with_metrics.sh
+++ b/scripts/start_with_metrics.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Start metrics server in background and launch orchestrator.
+# Metrics server listens on METRICS_PORT (default 8000).
+
+set -euo pipefail
+
+python3.11 -m core.metrics --port "${METRICS_PORT:-8000}" &
+python3.11 -m core.orchestrator --config=config.yaml "$@"


### PR DESCRIPTION
## Summary
- add `scripts/start_with_metrics.sh` to launch metrics server before orchestrator
- update Dockerfile to use the new script as default command
- keep port 8000 exposed in `docker-compose.yml`

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `forge test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`

------
https://chatgpt.com/codex/tasks/task_e_6845dde9cfd8832c810cdd0dba57ab1f