### PR TITLE
Add metrics endpoint check in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,13 @@ jobs:
         run: mypy --strict .
       - name: Run tests
         run: pytest -v
+      - name: Metrics endpoint
+        run: |
+          python3.11 -m core.metrics --port 8001 &
+          PID=$!
+          sleep 2
+          curl -f http://localhost:8001/metrics
+          kill $PID
       - name: Fork simulation
         run: bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
       - name: DRP dry run


### PR DESCRIPTION
## Summary
- run a quick metrics health check during CI after the test suite

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Unused "type: ignore" comments in chaos modules)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6845e1c03644832cbfa5a92892ad9b07