### PR TITLE
Add async run entrypoints

### DIFF
--- a/strategies/cross_domain_arb/strategy.py
+++ b/strategies/cross_domain_arb/strategy.py
@@ -23,6 +23,7 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, TypedDict, List
 
@@ -597,3 +598,40 @@ class CrossDomainArb(BaseStrategy):
                 )
             except Exception as exc:  # pragma: no cover - input validation
                 log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")
+
+
+async def run(
+    block_number: int | None = None,
+    chain_id: int | None = None,
+    test_mode: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Execute :meth:`CrossDomainArb.run_once` with async launcher."""
+
+    if block_number is not None:
+        os.environ["BLOCK_NUMBER"] = str(block_number)
+    if chain_id is not None:
+        os.environ["CHAIN_ID"] = str(chain_id)
+    if test_mode:
+        os.environ["TEST_MODE"] = "1"
+
+    strategy = CrossDomainArb({}, {}, **kwargs)
+    start = time.monotonic()
+    strategy.run_once()
+    latency = time.monotonic() - start
+    LOG.log(
+        "run_latency",
+        strategy_id=STRATEGY_ID,
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        latency=latency,
+        block=block_number,
+        chain_id=chain_id,
+        test_mode=test_mode,
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run())

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -363,3 +363,40 @@ class L3AppRollupMEV:
             except Exception as exc:
                 log_error(STRATEGY_ID, f"mutate edges_enabled: {exc}", event="mutate_error")
 
+
+async def run(
+    block_number: int | None = None,
+    chain_id: int | None = None,
+    test_mode: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Execute :meth:`L3AppRollupMEV.run_once` with async launcher."""
+
+    if block_number is not None:
+        os.environ["BLOCK_NUMBER"] = str(block_number)
+    if chain_id is not None:
+        os.environ["CHAIN_ID"] = str(chain_id)
+    if test_mode:
+        os.environ["TEST_MODE"] = "1"
+
+    strategy = L3AppRollupMEV({}, {}, **kwargs)
+    start = time.monotonic()
+    strategy.run_once()
+    latency = time.monotonic() - start
+    LOG.log(
+        "run_latency",
+        strategy_id=STRATEGY_ID,
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        latency=latency,
+        block=block_number,
+        chain_id=chain_id,
+        test_mode=test_mode,
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run())
+

--- a/strategies/l3_sequencer_mev/strategy.py
+++ b/strategies/l3_sequencer_mev/strategy.py
@@ -323,3 +323,40 @@ class L3SequencerMEV:
                 )
             except Exception as exc:
                 log_error(STRATEGY_ID, f"mutate reorg_window: {exc}", event="mutate_error")
+
+
+async def run(
+    block_number: int | None = None,
+    chain_id: int | None = None,
+    test_mode: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Execute :meth:`L3SequencerMEV.run_once` with latency tracking."""
+
+    if block_number is not None:
+        os.environ["BLOCK_NUMBER"] = str(block_number)
+    if chain_id is not None:
+        os.environ["CHAIN_ID"] = str(chain_id)
+    if test_mode:
+        os.environ["TEST_MODE"] = "1"
+
+    strategy = L3SequencerMEV({}, **kwargs)
+    start = time.monotonic()
+    strategy.run_once()
+    latency = time.monotonic() - start
+    LOG.log(
+        "run_latency",
+        strategy_id=STRATEGY_ID,
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        latency=latency,
+        block=block_number,
+        chain_id=chain_id,
+        test_mode=test_mode,
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run())

--- a/strategies/nft_liquidation/strategy.py
+++ b/strategies/nft_liquidation/strategy.py
@@ -229,3 +229,40 @@ class NFTLiquidationMEV:
             except Exception as exc:
                 log_error(STRATEGY_ID, f"mutate discount: {exc}", event="mutate_error")
 
+
+async def run(
+    block_number: int | None = None,
+    chain_id: int | None = None,
+    test_mode: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Execute :meth:`NFTLiquidationMEV.run_once` with latency tracking."""
+
+    if block_number is not None:
+        os.environ["BLOCK_NUMBER"] = str(block_number)
+    if chain_id is not None:
+        os.environ["CHAIN_ID"] = str(chain_id)
+    if test_mode:
+        os.environ["TEST_MODE"] = "1"
+
+    strategy = NFTLiquidationMEV({}, **kwargs)
+    start = time.monotonic()
+    strategy.run_once()
+    latency = time.monotonic() - start
+    LOG.log(
+        "run_latency",
+        strategy_id=STRATEGY_ID,
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        latency=latency,
+        block=block_number,
+        chain_id=chain_id,
+        test_mode=test_mode,
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run())
+

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -249,3 +249,40 @@ class RWASettlementMEV:
             except Exception as exc:
                 log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")
 
+
+async def run(
+    block_number: int | None = None,
+    chain_id: int | None = None,
+    test_mode: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Execute :meth:`RWASettlementMEV.run_once` with latency tracking."""
+
+    if block_number is not None:
+        os.environ["BLOCK_NUMBER"] = str(block_number)
+    if chain_id is not None:
+        os.environ["CHAIN_ID"] = str(chain_id)
+    if test_mode:
+        os.environ["TEST_MODE"] = "1"
+
+    strategy = RWASettlementMEV({}, **kwargs)
+    start = time.monotonic()
+    strategy.run_once()
+    latency = time.monotonic() - start
+    LOG.log(
+        "run_latency",
+        strategy_id=STRATEGY_ID,
+        mutation_id=os.getenv("MUTATION_ID", "dev"),
+        risk_level="low",
+        latency=latency,
+        block=block_number,
+        chain_id=chain_id,
+        test_mode=test_mode,
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- expose async `run()` wrappers for all strategies
- measure latency with `time.monotonic()` and log results
- add simple `__main__` launchers

## Testing
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `PYTHON=python3.11 scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e360b794832cb976fc5de2101ca8