### PR TITLE
Add Prometheus metrics counters to strategies

### DIFF
--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -33,10 +33,42 @@ from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 import time
+try:
+    from prometheus_client import Counter, Histogram, start_http_server
+except Exception:  # pragma: no cover - optional
+    Counter = Histogram = None  # type: ignore
+
+    def start_http_server(*_a: object, **_k: object) -> None:  # type: ignore
+        pass
 
 LOG_FILE = Path(os.getenv("L3_APP_ROLLUP_LOG", "logs/l3_app_rollup_mev.json"))
 LOG = StructuredLogger("l3_app_rollup_mev", log_file=str(LOG_FILE))
 STRATEGY_ID = "l3_app_rollup_mev"
+
+if Counter:
+    arb_opportunities_found = Counter(
+        "arb_opportunities_found", "Total arb opps"
+    )
+    arb_profit_eth = Counter(
+        "arb_profit_eth", "Cumulative ETH profit"
+    )
+    arb_latency = Histogram("arb_latency", "Latency for arbs")
+    arb_error_count = Counter(
+        "arb_error_count", "Errors during arb"
+    )
+    try:
+        start_http_server(int(os.getenv("PROMETHEUS_PORT", "8000")))
+    except Exception:
+        pass
+else:  # pragma: no cover - metrics optional
+    class _Dummy:
+        def inc(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def observe(self, *_a: object, **_k: object) -> None:
+            pass
+
+    arb_opportunities_found = arb_profit_eth = arb_latency = arb_error_count = _Dummy()
 
 
 @dataclass
@@ -262,6 +294,7 @@ class L3AppRollupMEV:
                 log_error(STRATEGY_ID, str(exc), event="price_fetch", domain=cfg.domain)
                 self.failed_pools[label] = self.failed_pools.get(label, 0) + 1
                 metrics.record_fail()
+                arb_error_count.inc()
                 return None
             price_data[label] = data
             self.last_prices[label] = data.price
@@ -273,6 +306,7 @@ class L3AppRollupMEV:
         if any(d.block_age > int(os.getenv("PRICE_FRESHNESS_SEC", "30")) for d in price_data.values()):
             log_error(STRATEGY_ID, "stale price detected", event="stale_price")
             metrics.record_fail()
+            arb_error_count.inc()
             return None
 
         prices = {k: d.price for k, d in price_data.items()}
@@ -305,6 +339,9 @@ class L3AppRollupMEV:
             self.tx_builder.snapshot(tx_post)
             self.snapshot(post)
             metrics.record_opportunity(float(opp["spread"]), float(opp["profit"]), latency)
+            arb_opportunities_found.inc()
+            arb_profit_eth.inc(float(opp["profit"]))
+            arb_latency.observe(latency)
 
             self.capital_lock.record_trade(float(opp["profit"]))
             for label, data in price_data.items():
@@ -318,6 +355,7 @@ class L3AppRollupMEV:
                 )
         else:
             metrics.record_fail()
+            arb_error_count.inc()
 
         return opp
 

--- a/strategies/l3_sequencer_mev/strategy.py
+++ b/strategies/l3_sequencer_mev/strategy.py
@@ -22,6 +22,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, TypedDict, cast
 import time
+try:
+    from prometheus_client import Counter, Histogram, start_http_server
+except Exception:  # pragma: no cover - optional
+    Counter = Histogram = None  # type: ignore
+
+    def start_http_server(*_a: object, **_k: object) -> None:  # type: ignore
+        pass
 
 from core.logger import StructuredLogger, log_error, make_json_safe
 from core import metrics
@@ -34,6 +41,31 @@ from agents.capital_lock import CapitalLock
 LOG_FILE = Path(os.getenv("L3_SEQ_LOG", "logs/l3_sequencer_mev.json"))
 LOG = StructuredLogger("l3_sequencer_mev", log_file=str(LOG_FILE))
 STRATEGY_ID = "l3_sequencer_mev"
+
+if Counter:
+    arb_opportunities_found = Counter(
+        "arb_opportunities_found", "Total arb opps"
+    )
+    arb_profit_eth = Counter(
+        "arb_profit_eth", "Cumulative ETH profit"
+    )
+    arb_latency = Histogram("arb_latency", "Latency for arbs")
+    arb_error_count = Counter(
+        "arb_error_count", "Errors during arb"
+    )
+    try:
+        start_http_server(int(os.getenv("PROMETHEUS_PORT", "8000")))
+    except Exception:
+        pass
+else:  # pragma: no cover - metrics optional
+    class _Dummy:
+        def inc(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def observe(self, *_a: object, **_k: object) -> None:
+            pass
+
+    arb_opportunities_found = arb_profit_eth = arb_latency = arb_error_count = _Dummy()
 
 
 @dataclass
@@ -222,6 +254,7 @@ class L3SequencerMEV:
             except Exception as exc:
                 log_error(STRATEGY_ID, str(exc), event="price_fetch", domain=cfg.domain)
                 metrics.record_fail()
+                arb_error_count.inc()
                 return None
             price_data[label] = data
             self.last_prices[label] = data.price
@@ -235,6 +268,7 @@ class L3SequencerMEV:
         if any(d.block_age > int(os.getenv("PRICE_FRESHNESS_SEC", "30")) for d in price_data.values()):
             log_error(STRATEGY_ID, "stale price detected", event="stale_price")
             metrics.record_fail()
+            arb_error_count.inc()
             return None
 
         prices = {k: d.price for k, d in price_data.items()}
@@ -265,6 +299,9 @@ class L3SequencerMEV:
             self.tx_builder.snapshot(tx_post)
             self.snapshot(post)
             metrics.record_opportunity(float(opp["spread"]), float(opp["profit"]), latency)
+            arb_opportunities_found.inc()
+            arb_profit_eth.inc(float(opp["profit"]))
+            arb_latency.observe(latency)
             self.capital_lock.record_trade(float(opp["profit"]))
             self.last_block = block
             for label, data in price_data.items():
@@ -278,6 +315,7 @@ class L3SequencerMEV:
                 )
         else:
             metrics.record_fail()
+            arb_error_count.inc()
             self.last_block = block
 
         return opp

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -29,10 +29,42 @@ from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 import time
+try:
+    from prometheus_client import Counter, Histogram, start_http_server
+except Exception:  # pragma: no cover - optional
+    Counter = Histogram = None  # type: ignore
+
+    def start_http_server(*_a: object, **_k: object) -> None:  # type: ignore
+        pass
 
 LOG_FILE = Path(os.getenv("RWA_SETTLE_LOG", "logs/rwa_settlement.json"))
 LOG = StructuredLogger("rwa_settlement", log_file=str(LOG_FILE))
 STRATEGY_ID = "rwa_settlement"
+
+if Counter:
+    arb_opportunities_found = Counter(
+        "arb_opportunities_found", "Total arb opps"
+    )
+    arb_profit_eth = Counter(
+        "arb_profit_eth", "Cumulative ETH profit"
+    )
+    arb_latency = Histogram("arb_latency", "Latency for arbs")
+    arb_error_count = Counter(
+        "arb_error_count", "Errors during arb"
+    )
+    try:
+        start_http_server(int(os.getenv("PROMETHEUS_PORT", "8000")))
+    except Exception:
+        pass
+else:  # pragma: no cover - metrics optional
+    class _Dummy:
+        def inc(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def observe(self, *_a: object, **_k: object) -> None:
+            pass
+
+    arb_opportunities_found = arb_profit_eth = arb_latency = arb_error_count = _Dummy()
 
 
 @dataclass
@@ -181,6 +213,7 @@ class RWASettlementMEV:
             except Exception as exc:
                 log_error(STRATEGY_ID, str(exc), event="price_fetch", venue=cfg.venue)
                 metrics.record_fail()
+                arb_error_count.inc()
                 return None
             price_data[label] = data
             self.last_prices[label] = data.price
@@ -216,6 +249,9 @@ class RWASettlementMEV:
             self.tx_builder.snapshot(tx_post)
             self.snapshot(post)
             metrics.record_opportunity(float(opp["spread"]), 0.0, latency)
+            arb_opportunities_found.inc()
+            arb_profit_eth.inc(0.0)
+            arb_latency.observe(latency)
 
             profit = prices[opp["sell"]] - prices[opp["buy"]]
             self.capital_lock.record_trade(profit)
@@ -231,6 +267,7 @@ class RWASettlementMEV:
             return opp
 
         metrics.record_fail()
+        arb_error_count.inc()
         return None
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include optional Prometheus metrics in each strategy
- increment the counters when opportunities, profits or errors occur
- expose Prometheus metrics server using `start_http_server`

## Testing
- `ruff check .`
- `mypy --strict` *(fails: unused ignore comments and other errors)*
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e39e1774832c8326927364ccc0c5