### PR TITLE
Add async run loop with kill conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ the values used in tests and the simulation harness:
 | `CROSS_ARB_STATE_PRE` | `state/cross_arb_pre.json` | DRP snapshot before execution |
 | `CROSS_ARB_TX_POST` | `state/tx_post.json` | Tx builder snapshot after |
 | `CROSS_ARB_TX_PRE` | `state/tx_pre.json` | Tx builder snapshot before |
+| `ARB_LATENCY_THRESHOLD` | `60` | Max average latency before shutdown |
+| `ARB_ERROR_LIMIT` | `5` | Consecutive errors before shutdown |
 | `CROSS_ROLLUP_LOG` | `logs/cross_rollup_superbot.json` | cross_rollup_superbot log |
 | `ERROR_LOG_FILE` | `logs/errors.log` | Shared error log |
 | `DRP_ENC_KEY` | `<none>` | Optional key to encrypt DRP archives |

--- a/infra/sim_harness/chaos_drill.py
+++ b/infra/sim_harness/chaos_drill.py
@@ -124,7 +124,7 @@ def _drill_lost_agent(env: dict[str, str]) -> None:
 
 def _drill_adapter_fail(env: dict[str, str]) -> None:
     try:
-        adapter = DEXAdapter("http://127.0.0.1:1")  # type: ignore[misc]
+        adapter = DEXAdapter("http://127.0.0.1:1")
         adapter.get_quote("ETH", "USDC", 1)
     except Exception:
         LOGGER.log("adapter_fail", risk_level="high")
@@ -134,7 +134,7 @@ def _drill_adapter_fail(env: dict[str, str]) -> None:
 
 def _drill_bridge_fail(env: dict[str, str]) -> None:
     try:
-        adapter = BridgeAdapter("http://127.0.0.1:1")  # type: ignore[misc]
+        adapter = BridgeAdapter("http://127.0.0.1:1")
         adapter.bridge("eth", "arb", "ETH", 1)
     except Exception:
         LOGGER.log("bridge_fail", risk_level="high")
@@ -144,7 +144,7 @@ def _drill_bridge_fail(env: dict[str, str]) -> None:
 
 def _drill_cex_fail(env: dict[str, str]) -> None:
     try:
-        adapter = CEXAdapter("http://127.0.0.1:1", "bad")  # type: ignore[misc]
+        adapter = CEXAdapter("http://127.0.0.1:1", "bad")
         adapter.place_order("buy", 1, 1)
     except Exception:
         LOGGER.log("cex_fail", risk_level="high")
@@ -154,7 +154,7 @@ def _drill_cex_fail(env: dict[str, str]) -> None:
 
 def _drill_flashloan_fail(env: dict[str, str]) -> None:
     try:
-        adapter = FlashloanAdapter("http://127.0.0.1:1")  # type: ignore[misc]
+        adapter = FlashloanAdapter("http://127.0.0.1:1")
         adapter.trigger("ETH", 1)
     except Exception:
         LOGGER.log("flashloan_fail", risk_level="high")
@@ -233,7 +233,7 @@ def _drill_rpc_fail(env: dict[str, str]) -> None:
 
 def _drill_data_dos(env: dict[str, str]) -> None:
     try:
-        adapter = DEXAdapter("http://127.0.0.1:1")  # type: ignore[misc]
+        adapter = DEXAdapter("http://127.0.0.1:1")
         adapter.get_quote("ETH", "USDC", 1, simulate_failure="data_poison")
     except Exception:
         LOGGER.log("data_dos", risk_level="high")

--- a/infra/sim_harness/chaos_scheduler.py
+++ b/infra/sim_harness/chaos_scheduler.py
@@ -28,10 +28,10 @@ OPS = OpsAgent({})
 
 
 ADAPTER_FUNCS: Dict[str, Callable[[str], Dict[str, Any]]] = {
-    "dex": lambda mode: DEXAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).get_quote("ETH", "USDC", 1, simulate_failure=mode),  # type: ignore[misc]
-    "bridge": lambda mode: BridgeAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).bridge("eth", "arb", "ETH", 1, simulate_failure=mode),  # type: ignore[misc]
-    "cex": lambda mode: CEXAdapter("http://bad", "k", alt_api_urls=["http://alt"], ops_agent=OPS).get_balance(simulate_failure=mode),  # type: ignore[misc]
-    "flashloan": lambda mode: FlashloanAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).trigger("ETH", 1, simulate_failure=mode),  # type: ignore[misc]
+    "dex": lambda mode: DEXAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).get_quote("ETH", "USDC", 1, simulate_failure=mode),
+    "bridge": lambda mode: BridgeAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).bridge("eth", "arb", "ETH", 1, simulate_failure=mode),
+    "cex": lambda mode: CEXAdapter("http://bad", "k", alt_api_urls=["http://alt"], ops_agent=OPS).get_balance(simulate_failure=mode),
+    "flashloan": lambda mode: FlashloanAdapter("http://bad", alt_api_urls=["http://alt"], ops_agent=OPS).trigger("ETH", 1, simulate_failure=mode),
 }
 
 
@@ -71,8 +71,8 @@ def main() -> None:
     interval = int(os.getenv("CHAOS_INTERVAL", "600"))
     once = os.getenv("CHAOS_ONCE") == "1"
     while True:
-        if kill_switch_triggered and kill_switch_triggered():
-            if record_kill_event:
+        if kill_switch_triggered is not None and kill_switch_triggered():
+            if record_kill_event is not None:
                 record_kill_event("chaos_scheduler")
             break
         run_once()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,11 +23,14 @@ def test_metrics_server(tmp_path):
         "arb_profit": 0.0,
         "arb_latency": [],
         "error_count": 0,
+        "arb_error_count": 0,
     })
 
     metrics.record_opportunity(0.1, 5.0, 0.5)
     metrics.record_fail()
     metrics.record_alert()
+    metrics.record_latency(0.5)
+    metrics.record_arb_error()
 
     host, port = srv.server.server_address
     url = f"http://{host}:{port}/metrics"
@@ -40,6 +43,8 @@ def test_metrics_server(tmp_path):
     assert "opportunities_found_total 1" in data
     assert "arb_profit_total 5.0" in data
     assert "error_count 1" in data
+    assert "arb_error_count 1" in data
+    assert "avg_arb_latency_seconds 0.5" in data
 
 
 def _start_server_with_token(monkeypatch, token):


### PR DESCRIPTION
## Summary
- support arb error count metric and latency gauge
- add async `run` loop in `cross_domain_arb` with kill thresholds
- expose `ARB_LATENCY_THRESHOLD` and `ARB_ERROR_LIMIT` env vars in docs
- update metrics server and tests for new metrics
- remove unused mypy ignores

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e39ee518832c8f3f32ee5544dc15