### PR TITLE
Add codex diff logging

### DIFF
--- a/tests/test_codex_diff_log.py
+++ b/tests/test_codex_diff_log.py
@@ -1,0 +1,45 @@
+import json
+import sys
+
+from ai.mutator.mutator import Mutator
+
+
+class FakeMsg:
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeResp:
+    def __init__(self, text):
+        self.choices = [type("C", (), {"message": FakeMsg(text)})]
+
+
+class FakeChat:
+    @staticmethod
+    def create(model, messages):
+        return FakeResp('{"params": {"threshold": 0.1}}')
+
+
+def test_codex_diff_logging(monkeypatch, tmp_path):
+    diff_dir = tmp_path / "diffs"
+    monkeypatch.setenv("CODEX_DIFF_DIR", str(diff_dir))
+
+    strat_dir = tmp_path / "strategies" / "foo"
+    strat_dir.mkdir(parents=True)
+    (strat_dir / "strategy.py").write_text("class Foo:\n    pass\n")
+
+    monkeypatch.setitem(sys.modules, "openai", type("O", (), {"ChatCompletion": FakeChat}))
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+
+    metrics = {"foo": {"pnl": 1}}
+    mut = Mutator(metrics, strategy_root=str(tmp_path / "strategies"), live=True)
+
+    for _ in range(4):
+        mut.mutate("foo")
+
+    log_file = diff_dir / "foo.json"
+    assert log_file.exists()
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert len(entries) == 3
+    assert "patch_id" in entries[-1]
+    assert "prompt_hash" in entries[-1]


### PR DESCRIPTION
## Summary
- log prompt and patch hashes for each mutate call
- keep only last three entries for a strategy
- store codex diff logs in configurable `/last_3_codex_diffs`
- test codex diff logging

## Testing
- `ruff check .`
- `mypy --strict ai/mutator/mutator.py tests/test_codex_diff_log.py`
- `pytest -v tests/test_codex_diff_log.py`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/foo` *(fails: unknown target)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/foo.json`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6845e3a74844832c886750fb4b8fc9df