### PR TITLE
Add kill thresholds to cross_domain_arb run loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ the values used in tests and the simulation harness:
 |----------|---------|---------|
 | `ARB_ALERT_WEBHOOK` | `<none>` | Alert URL for cross_domain_arb |
 | `ARB_EXECUTOR_ADDR` | `0x000...` | Executor address for cross_domain_arb |
+| `ARB_ERROR_LIMIT` | `3` | Consecutive error threshold before kill |
+| `ARB_LATENCY_THRESHOLD` | `30` | Average latency threshold in seconds |
 | `BRIDGE_LATENCY_MAX` | `30` | Max seconds for bridge to finalize |
 | `CROSS_ARB_LOG` | `logs/cross_domain_arb.json` | cross_domain_arb log |
 | `CROSS_ARB_STATE_POST` | `state/cross_arb_post.json` | DRP snapshot after execution |

--- a/tests/test_run_kill.py
+++ b/tests/test_run_kill.py
@@ -1,0 +1,28 @@
+import importlib
+import pytest
+
+pytest.importorskip("strategies.cross_domain_arb.strategy")
+
+
+@pytest.mark.asyncio
+async def test_run_kill(monkeypatch):
+    mod = importlib.import_module("strategies.cross_domain_arb.strategy")
+
+    class Dummy(mod.CrossDomainArb):
+        def run_once(self):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(mod, "CrossDomainArb", Dummy)
+    monkeypatch.setenv("ARB_ERROR_LIMIT", "0")
+    monkeypatch.setenv("ARB_LATENCY_THRESHOLD", "100")
+
+    called = []
+    monkeypatch.setattr(mod, "record_kill_event", lambda origin: called.append(origin))
+
+    with pytest.raises(SystemExit) as se:
+        await mod.run(test_mode=True)
+
+    assert se.value.code == 137
+    assert called and called[0] == mod.STRATEGY_ID
+
+


### PR DESCRIPTION
## Summary
- monitor `run()` loop for cross_domain_arb with latency and error metrics
- exit with `record_kill_event` if thresholds exceeded
- document new tuning environment variables
- test kill behaviour

## Testing
- `ruff check`
- `mypy --strict` *(fails: unused ignore comments)*
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e6a98518832c9e3f34f675f4aa9e