### PR TITLE
Add gas-aware trade abort logic

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -38,6 +38,7 @@ _METRICS: Dict[str, Any] = {
     "arb_profit": 0.0,
     "arb_latency": [],
     "error_count": 0,
+    "abort_total": 0,
 }
 _LOCK = threading.Lock()
 _METRICS_TOKEN = os.getenv("METRICS_TOKEN")
@@ -95,6 +96,12 @@ def record_mutation_event() -> None:
         _METRICS["mutation_events"] = cast(int, _METRICS.get("mutation_events", 0)) + 1
 
 
+def record_abort() -> None:
+    """Record a trade abort decision."""
+    with _LOCK:
+        _METRICS["abort_total"] = cast(int, _METRICS.get("abort_total", 0)) + 1
+
+
 # ----------------------------------------------------------------------
 # Metrics server
 # ----------------------------------------------------------------------
@@ -129,6 +136,7 @@ class _Handler(BaseHTTPRequestHandler):
                 f"prune_total {_METRICS['prune_total']}\n"
                 f"decay_alerts {_METRICS['decay_alerts']}\n"
                 f"mutation_events {_METRICS['mutation_events']}\n"
+                f"abort_total {_METRICS['abort_total']}\n"
                 f"opportunities_found_total {_METRICS['opportunities_found']}\n"
                 f"arb_profit_total {_METRICS['arb_profit']}\n"
                 f"avg_arb_latency_seconds {avg_arb_latency}\n"

--- a/strategies/cross_rollup_superbot/strategy.py
+++ b/strategies/cross_rollup_superbot/strategy.py
@@ -41,9 +41,9 @@ import time
 try:
     from prometheus_client import Counter, Histogram, start_http_server
 except Exception:  # pragma: no cover - optional
-    Counter = Histogram = None  # type: ignore
+    Counter = Histogram = None
 
-    def start_http_server(*_a: object, **_k: object) -> None:  # type: ignore
+    def start_http_server(*_a: object, **_k: object) -> None:
         pass
 
 LOG_FILE = Path(os.getenv("CROSS_ROLLUP_LOG", "logs/cross_rollup_superbot.json"))
@@ -61,6 +61,10 @@ if Counter:
     arb_error_count = Counter(
         "arb_error_count", "Errors during arb"
     )
+    arb_abort_count = Counter(
+        "arb_abort_count",
+        "Aborted arb trades",
+    )
     try:
         start_http_server(int(os.getenv("PROMETHEUS_PORT", "8000")))
     except Exception:
@@ -73,7 +77,15 @@ else:  # pragma: no cover - metrics optional
         def observe(self, *_a: object, **_k: object) -> None:
             pass
 
-    arb_opportunities_found = arb_profit_eth = arb_latency = arb_error_count = _Dummy()
+    arb_opportunities_found = (
+        arb_profit_eth
+    ) = (
+        arb_latency
+    ) = (
+        arb_error_count
+    ) = (
+        arb_abort_count
+    ) = _Dummy()
 
 
 @dataclass
@@ -114,6 +126,7 @@ class CrossRollupSuperbot:
         *,
         capital_lock: CapitalLock | None = None,
         nonce_manager: NonceManager | None = None,
+        capital_base_eth: float = 1.0,
     ) -> None:
         self.feed = UniswapV3Feed()
         self.pools = pools
@@ -122,6 +135,8 @@ class CrossRollupSuperbot:
         self.last_prices: Dict[str, float] = {}
         self.failed_pools: Dict[str, int] = {}
         self.max_failures = 3
+
+        self.capital_base_eth = capital_base_eth
 
         self.capital_lock = capital_lock or CapitalLock(1000.0, 1e9, 0.0)
 
@@ -181,7 +196,7 @@ class CrossRollupSuperbot:
         spread = (prices[sell] - prices[buy]) / prices[buy]
         if spread < self.threshold:
             return None
-        profit = self._compute_profit(buy, sell, 1.0, prices)
+        profit = self._compute_profit(buy, sell, self.capital_base_eth, prices)
         if profit <= 0:
             return None
         action = f"bundle_buy:{buy}_sell:{sell}"
@@ -285,6 +300,39 @@ class CrossRollupSuperbot:
         prices = {k: d.price for k, d in price_data.items()}
         opp = self._detect_opportunity(prices)
         if opp:
+            profit = float(opp["profit"])
+            gas_price = getattr(self.tx_builder.web3.eth, "gas_price", 0)
+            min_gas_cost = float(gas_price * 21000) / 1e18 * 1.5
+            est_slippage = abs(
+                prices[opp["buy"]] - self.last_prices.get(opp["buy"], prices[opp["buy"]])
+            ) / prices[opp["buy"]]
+            slip_tol = float(os.getenv("SLIPPAGE_PCT", "0"))
+            if profit < min_gas_cost:
+                LOG.log(
+                    "trade_abort",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    reason="low_pnl",
+                    projected_pnl=profit,
+                    threshold=min_gas_cost,
+                )
+                metrics.record_abort()
+                arb_abort_count.inc()
+                return None
+            if est_slippage > slip_tol:
+                LOG.log(
+                    "trade_abort",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="medium",
+                    reason="slippage",
+                    slippage=est_slippage,
+                    tolerance=slip_tol,
+                )
+                metrics.record_abort()
+                arb_abort_count.inc()
+                return None
             if not self.capital_lock.trade_allowed():
                 msg = "capital lock: trade not allowed"
                 LOG.log(

--- a/strategies/rwa_settlement/strategy.py
+++ b/strategies/rwa_settlement/strategy.py
@@ -32,9 +32,9 @@ import time
 try:
     from prometheus_client import Counter, Histogram, start_http_server
 except Exception:  # pragma: no cover - optional
-    Counter = Histogram = None  # type: ignore
+    Counter = Histogram = None
 
-    def start_http_server(*_a: object, **_k: object) -> None:  # type: ignore
+    def start_http_server(*_a: object, **_k: object) -> None:
         pass
 
 LOG_FILE = Path(os.getenv("RWA_SETTLE_LOG", "logs/rwa_settlement.json"))
@@ -52,6 +52,10 @@ if Counter:
     arb_error_count = Counter(
         "arb_error_count", "Errors during arb"
     )
+    arb_abort_count = Counter(
+        "arb_abort_count",
+        "Aborted arb trades",
+    )
     try:
         start_http_server(int(os.getenv("PROMETHEUS_PORT", "8000")))
     except Exception:
@@ -64,7 +68,15 @@ else:  # pragma: no cover - metrics optional
         def observe(self, *_a: object, **_k: object) -> None:
             pass
 
-    arb_opportunities_found = arb_profit_eth = arb_latency = arb_error_count = _Dummy()
+    arb_opportunities_found = (
+        arb_profit_eth
+    ) = (
+        arb_latency
+    ) = (
+        arb_error_count
+    ) = (
+        arb_abort_count
+    ) = _Dummy()
 
 
 @dataclass
@@ -93,6 +105,7 @@ class RWASettlementMEV:
         threshold: float | None = None,
         capital_lock: CapitalLock | None = None,
         nonce_manager: NonceManager | None = None,
+        capital_base_eth: float = 1.0,
     ) -> None:
         self.feed = RWAFeed()
         self.venues = venues
@@ -106,6 +119,7 @@ class RWASettlementMEV:
         self.sample_tx = HexBytes(b"\x01")
 
         self.capital_lock = capital_lock or CapitalLock(1000.0, 1e9, 0.0)
+        self.capital_base_eth = capital_base_eth
 
     # ------------------------------------------------------------------
     def snapshot(self, path: str) -> None:
@@ -225,6 +239,39 @@ class RWASettlementMEV:
         prices = {k: d.price + d.fee for k, d in price_data.items()}
         opp = self._detect_opportunity(prices)
         if opp:
+            profit = (prices[opp["sell"]] - prices[opp["buy"]]) * self.capital_base_eth
+            gas_price = getattr(self.tx_builder.web3.eth, "gas_price", 0)
+            min_gas_cost = float(gas_price * 21000) / 1e18 * 1.5
+            est_slippage = abs(
+                prices[opp["buy"]] - self.last_prices.get(opp["buy"], prices[opp["buy"]])
+            ) / prices[opp["buy"]]
+            slip_tol = float(os.getenv("SLIPPAGE_PCT", "0"))
+            if profit < min_gas_cost:
+                LOG.log(
+                    "trade_abort",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="low",
+                    reason="low_pnl",
+                    projected_pnl=profit,
+                    threshold=min_gas_cost,
+                )
+                metrics.record_abort()
+                arb_abort_count.inc()
+                return None
+            if est_slippage > slip_tol:
+                LOG.log(
+                    "trade_abort",
+                    strategy_id=STRATEGY_ID,
+                    mutation_id=os.getenv("MUTATION_ID", "dev"),
+                    risk_level="medium",
+                    reason="slippage",
+                    slippage=est_slippage,
+                    tolerance=slip_tol,
+                )
+                metrics.record_abort()
+                arb_abort_count.inc()
+                return None
             if not self.capital_lock.trade_allowed():
                 msg = "capital lock: trade not allowed"
                 LOG.log(


### PR DESCRIPTION
## Summary
- make abort events observable via metrics
- include gas/slippage checks before trades across strategies
- allow configuring capital_base_eth on each strategy

## Testing
- `ruff check .`
- `mypy --strict strategies core/metrics.py`
- `pytest -v` *(fails: Port 8000 already in use)*
- `foundry test` *(fails: command not found)*
- `scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e8470140832cade0f7bbecd2e519