### PR TITLE
Fix run tests

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,6 +27,7 @@ def reset_metrics() -> None:
         "arb_profit": 0.0,
         "arb_latency": [],
         "error_count": 0,
+        "abort_total": 0,
     }
     yield
 
@@ -45,6 +46,7 @@ def test_metrics_server(tmp_path):
         "arb_profit": 0.0,
         "arb_latency": [],
         "error_count": 0,
+        "abort_total": 0,
     })
 
     metrics.record_opportunity(0.1, 5.0, 0.5)

--- a/tests/test_run_kill.py
+++ b/tests/test_run_kill.py
@@ -1,28 +1,56 @@
+import asyncio
 import importlib
+from typing import Any
+
 import pytest
 
 pytest.importorskip("strategies.cross_domain_arb.strategy")
 
 
-@pytest.mark.asyncio
-async def test_run_kill(monkeypatch):
+def _setup_failure(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Patch strategy to raise a runtime error."""
     mod = importlib.import_module("strategies.cross_domain_arb.strategy")
 
     class Dummy(mod.CrossDomainArb):
-        def run_once(self):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub
+            pass
+
+        def run_once(self) -> None:  # pragma: no cover - stub
             raise RuntimeError("fail")
 
     monkeypatch.setattr(mod, "CrossDomainArb", Dummy)
     monkeypatch.setenv("ARB_ERROR_LIMIT", "0")
     monkeypatch.setenv("ARB_LATENCY_THRESHOLD", "100")
+    return mod
 
-    called = []
+
+def test_run_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _setup_failure(monkeypatch)
+    called: list[str] = []
     monkeypatch.setattr(mod, "record_kill_event", lambda origin: called.append(origin))
 
     with pytest.raises(SystemExit) as se:
-        await mod.run(test_mode=True)
+        asyncio.run(mod.run(test_mode=True))
 
     assert se.value.code == 137
     assert called and called[0] == mod.STRATEGY_ID
 
 
+def test_run_kill_error_counter(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _setup_failure(monkeypatch)
+    called: list[str] = []
+    monkeypatch.setattr(mod, "record_kill_event", lambda origin: called.append(origin))
+
+    inc_calls: list[int] = []
+
+    class Counter:
+        def inc(self) -> None:  # pragma: no cover - stub
+            inc_calls.append(1)
+
+    monkeypatch.setattr(mod, "arb_error_count", Counter())
+
+    with pytest.raises(SystemExit):
+        asyncio.run(mod.run(test_mode=True))
+
+    assert called and called[0] == mod.STRATEGY_ID
+    assert inc_calls and len(inc_calls) == 1

--- a/tests/test_rwa_settlement.py
+++ b/tests/test_rwa_settlement.py
@@ -74,6 +74,7 @@ def _patch_flashbots(monkeypatch):
 def test_opportunity_detection(monkeypatch):
     _patch_flashbots(monkeypatch)
     monkeypatch.setenv("FLASHBOTS_AUTH_KEY", "0x" + "11" * 32)
+    monkeypatch.setenv("SLIPPAGE_PCT", "0.05")
     strat = setup_strat(threshold=0.01)
     feed_data = {
         ("dex", "asset"): RWAData(100, 0.1, 1),


### PR DESCRIPTION
## Summary
- patch metrics fixture for abort_total
- use `asyncio.run` for new strategy runner
- add chaos test verifying error counters and kill escalation
- fix RWA settlement test slippage tolerance

## Testing
- `ruff check tests/test_metrics.py tests/test_run_kill.py tests/test_rwa_settlement.py`
- `mypy --strict tests/test_rwa_settlement.py tests/test_run_kill.py tests/test_metrics.py`
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `PYTHONPATH=. bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: requests)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`

------
https://chatgpt.com/codex/tasks/task_e_6845eb9a5984832cbd179d21db27d9bb