### PR TITLE
Add EDGE_SCHEMA metadata

### DIFF
--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -1,20 +1,28 @@
-"""L3/app-rollup MEV strategy leveraging sandwich and bridge race edges.
-
-This module scans L3 rollups for price discrepancies relative to L2/L1 pools
-and monitors intent feeds for bridge transactions that can be frontrun.  It
-supports runtime mutation, DRP snapshot/restore and kill switch integration.
-
-Integration points and dependencies:
-    - :class:`core.oracles.uniswap_feed.UniswapV3Feed` for pool pricing.
-    - :class:`core.oracles.intent_feed.IntentFeed` for intent data.
-    - :class:`core.tx_engine.TransactionBuilder` and :class:`core.tx_engine.NonceManager` for dispatch.
-    - Kill switch utilities to abort on demand.
-
-Simulation/test hooks and kill conditions:
-    - Designed for forked-mainnet simulation via ``infra/sim_harness``.
-    - Snapshot and restore functions persist price and bridge state.
-    - Aborts immediately if the kill switch is triggered.
 """
+strategy_id: "BridgeArb_001"
+edge_type: "BridgeDelay"
+ttl_hours: 48
+triggers:
+  - bridge_delay_secs > 8
+  - price_gap_pct > 2
+"""
+
+# L3/app-rollup MEV strategy leveraging sandwich and bridge race edges.
+#
+# This module scans L3 rollups for price discrepancies relative to L2/L1 pools
+# and monitors intent feeds for bridge transactions that can be frontrun.  It
+# supports runtime mutation, DRP snapshot/restore and kill switch integration.
+#
+# Integration points and dependencies:
+#     - :class:`core.oracles.uniswap_feed.UniswapV3Feed` for pool pricing.
+#     - :class:`core.oracles.intent_feed.IntentFeed` for intent data.
+#     - :class:`core.tx_engine.TransactionBuilder` and :class:`core.tx_engine.NonceManager` for dispatch.
+#     - Kill switch utilities to abort on demand.
+#
+# Simulation/test hooks and kill conditions:
+#     - Designed for forked-mainnet simulation via ``infra/sim_harness``.
+#     - Snapshot and restore functions persist price and bridge state.
+#     - Aborts immediately if the kill switch is triggered.
 
 from __future__ import annotations
 
@@ -23,6 +31,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, TypedDict, cast
+import yaml
 
 from core.logger import StructuredLogger, log_error, make_json_safe
 from core import metrics
@@ -43,7 +52,8 @@ except Exception:  # pragma: no cover - optional
 
 LOG_FILE = Path(os.getenv("L3_APP_ROLLUP_LOG", "logs/l3_app_rollup_mev.json"))
 LOG = StructuredLogger("l3_app_rollup_mev", log_file=str(LOG_FILE))
-STRATEGY_ID = "l3_app_rollup_mev"
+EDGE_SCHEMA: Dict[str, Any] = yaml.safe_load(__doc__ or "")
+STRATEGY_ID = EDGE_SCHEMA["strategy_id"]
 
 if Counter:
     arb_opportunities_found = Counter(
@@ -176,7 +186,7 @@ class L3AppRollupMEV:
         LOG.log(
             "price",
             tx_id=tx_id,
-            strategy_id=STRATEGY_ID,
+            strategy_id=EDGE_SCHEMA["strategy_id"],
             mutation_id=os.getenv("MUTATION_ID", "dev"),
             risk_level="low",
             domain=domain,
@@ -223,7 +233,7 @@ class L3AppRollupMEV:
             try:
                 intents = self.intent_feed.fetch_intents(src)
             except Exception as exc:
-                log_error(STRATEGY_ID, f"intent fetch: {exc}", event="intent_fetch", domain=src)
+                log_error(EDGE_SCHEMA["strategy_id"], f"intent fetch: {exc}", event="intent_fetch", domain=src)
                 return None
             if not intents:
                 continue
@@ -272,11 +282,11 @@ class L3AppRollupMEV:
             return str(result.get("bundleHash")), latency
         except Exception as exc:  # pragma: no cover - runtime
             latency = time.time() - start
-            log_error(STRATEGY_ID, f"bundle send: {exc}", event="bundle_fail")
+            log_error(EDGE_SCHEMA["strategy_id"], f"bundle send: {exc}", event="bundle_fail")
             tx_hash = self.tx_builder.send_transaction(
                 self.sample_tx,
                 self.executor,
-                strategy_id=STRATEGY_ID,
+                strategy_id=EDGE_SCHEMA["strategy_id"],
                 mutation_id=os.getenv("MUTATION_ID", "dev"),
                 risk_level="low",
             )
@@ -290,10 +300,10 @@ class L3AppRollupMEV:
     # ------------------------------------------------------------------
     def run_once(self) -> Optional[Opportunity]:
         if kill_switch_triggered():
-            record_kill_event(STRATEGY_ID)
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
             LOG.log(
                 "killed",
-                strategy_id=STRATEGY_ID,
+                strategy_id=EDGE_SCHEMA["strategy_id"],
                 mutation_id=os.getenv("MUTATION_ID", "dev"),
                 risk_level="high",
             )
@@ -306,7 +316,7 @@ class L3AppRollupMEV:
             try:
                 data = self.feed.fetch_price(cfg.pool, cfg.domain)
             except Exception as exc:
-                log_error(STRATEGY_ID, str(exc), event="price_fetch", domain=cfg.domain)
+                log_error(EDGE_SCHEMA["strategy_id"], str(exc), event="price_fetch", domain=cfg.domain)
                 self.failed_pools[label] = self.failed_pools.get(label, 0) + 1
                 metrics.record_fail()
                 arb_error_count.inc()
@@ -319,7 +329,7 @@ class L3AppRollupMEV:
             return None
 
         if any(d.block_age > int(os.getenv("PRICE_FRESHNESS_SEC", "30")) for d in price_data.values()):
-            log_error(STRATEGY_ID, "stale price detected", event="stale_price")
+            log_error(EDGE_SCHEMA["strategy_id"], "stale price detected", event="stale_price")
             metrics.record_fail()
             arb_error_count.inc()
             return None
@@ -340,7 +350,7 @@ class L3AppRollupMEV:
             if profit < min_gas_cost:
                 LOG.log(
                     "trade_abort",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="low",
                     reason="low_pnl",
@@ -353,7 +363,7 @@ class L3AppRollupMEV:
             if est_slippage > slip_tol:
                 LOG.log(
                     "trade_abort",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="medium",
                     reason="slippage",
@@ -367,12 +377,12 @@ class L3AppRollupMEV:
                 msg = "capital lock: trade not allowed"
                 LOG.log(
                     "capital_lock",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="high",
                     error=msg,
                 )
-                log_error(STRATEGY_ID, msg, event="capital_lock", risk_level="high")
+                log_error(EDGE_SCHEMA["strategy_id"], msg, event="capital_lock", risk_level="high")
                 return None
 
             pre = os.getenv("L3_APP_STATE_PRE", "state/l3_app_pre.json")
@@ -414,14 +424,14 @@ class L3AppRollupMEV:
                 self.threshold = float(params["threshold"])
                 LOG.log(
                     "mutate",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="low",
                     param="threshold",
                     value=self.threshold,
                 )
             except Exception as exc:
-                log_error(STRATEGY_ID, f"mutate threshold: {exc}", event="mutate_error")
+                log_error(EDGE_SCHEMA["strategy_id"], f"mutate threshold: {exc}", event="mutate_error")
         if "bridge_costs" in params:
             try:
                 for k, v in params["bridge_costs"].items():
@@ -429,25 +439,25 @@ class L3AppRollupMEV:
                     self.bridge_costs[pair] = BridgeConfig(**v)
                 LOG.log(
                     "mutate",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="low",
                     param="bridge_costs",
                 )
             except Exception as exc:
-                log_error(STRATEGY_ID, f"mutate bridge_costs: {exc}", event="mutate_error")
+                log_error(EDGE_SCHEMA["strategy_id"], f"mutate bridge_costs: {exc}", event="mutate_error")
         if "edges_enabled" in params:
             try:
                 self.edges_enabled.update({str(k): bool(v) for k, v in params["edges_enabled"].items()})
                 LOG.log(
                     "mutate",
-                    strategy_id=STRATEGY_ID,
+                    strategy_id=EDGE_SCHEMA["strategy_id"],
                     mutation_id=os.getenv("MUTATION_ID", "dev"),
                     risk_level="low",
                     param="edges_enabled",
                 )
             except Exception as exc:
-                log_error(STRATEGY_ID, f"mutate edges_enabled: {exc}", event="mutate_error")
+                log_error(EDGE_SCHEMA["strategy_id"], f"mutate edges_enabled: {exc}", event="mutate_error")
 
 
 async def run(
@@ -471,7 +481,7 @@ async def run(
     latency = time.monotonic() - start
     LOG.log(
         "run_latency",
-        strategy_id=STRATEGY_ID,
+        strategy_id=EDGE_SCHEMA["strategy_id"],
         mutation_id=os.getenv("MUTATION_ID", "dev"),
         risk_level="low",
         latency=latency,


### PR DESCRIPTION
## Summary
- insert YAML docstrings as strategy metadata
- parse strategy metadata into `EDGE_SCHEMA` constant
- log `EDGE_SCHEMA['strategy_id']` for clarity

## Testing
- `python3.11 -m pip install -q -r requirements.txt` *(fails: No matching distribution found for flashbots==1.2.0)*
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: No module named 'strategies')*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6845ed5e727c832cb5d122b6a2d597e1