### PR TITLE
Add full project state export script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
         run: bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
       - name: DRP dry run
         run: bash scripts/export_state.sh --dry-run
+      - name: Project audit export
+        run: bash scripts/export_project_state.sh --dry-run
       - name: Offline audit
         run: python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
       - name: Chaos drill

--- a/infra/sim_harness/chaos_scheduler.py
+++ b/infra/sim_harness/chaos_scheduler.py
@@ -71,8 +71,8 @@ def main() -> None:
     interval = int(os.getenv("CHAOS_INTERVAL", "600"))
     once = os.getenv("CHAOS_ONCE") == "1"
     while True:
-        if kill_switch_triggered and kill_switch_triggered():
-            if record_kill_event:
+        if callable(kill_switch_triggered) and kill_switch_triggered():
+            if callable(record_kill_event):
                 record_kill_event("chaos_scheduler")
             break
         run_once()

--- a/scripts/export_project_state.sh
+++ b/scripts/export_project_state.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Export a full project snapshot for audits.
+# Includes git metadata, strategy TTL info, patch diffs, secrets config,
+# simulation results, and capital gate metrics.
+
+set -euo pipefail
+
+DRY=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY=1
+            shift
+            ;;
+        *)
+            echo "Usage: $0 [--dry-run]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+EXPORT_DIR="${EXPORT_DIR:-/export}"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+ARCHIVE="drp_export_FULL_${TIMESTAMP//:/-}.tar.gz"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+
+# --- meta info ---
+SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+AUDIT_SHA="$(git -C "$ROOT" log --grep='founder audit' -n1 --pretty=%H 2>/dev/null || true)"
+printf '{"timestamp":"%s","sha":"%s","audit_sha":"%s"}\n' "$TIMESTAMP" "$SHA" "${AUDIT_SHA:-}" > "$TMP_DIR/meta.json"
+
+# --- strategy TTL metadata ---
+TTL_FILE="$TMP_DIR/strategy_ttl.txt"
+if [[ -d "$ROOT/strategies" ]]; then
+    find "$ROOT/strategies" -name strategy.py | while read -r f; do
+        strat="$(basename "$(dirname "$f")")"
+        ttl="$(grep -m1 -E 'ttl_hours:' "$f" | awk '{print $2}')"
+        mtime="$(date -u -r "$f" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo unknown)"
+        echo "$strat ttl_hours=${ttl:-na} modified=$mtime" >> "$TTL_FILE"
+    done
+else
+    : > "$TTL_FILE"
+fi
+
+# --- capital gate summary ---
+if [[ -f "$ROOT/logs/scoreboard.json" ]]; then
+    python3.11 - "$ROOT/logs/scoreboard.json" "$TMP_DIR/capital_gate.json" <<'PY'
+import json, statistics, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    data = []
+vals = [float(d.get("pnl", 0)) for d in data]
+sharpe = [float(d.get("sharpe", 0)) for d in data]
+draw = [float(d.get("drawdown", 0)) for d in data]
+res = {
+    "median_pnl": statistics.median(vals) if vals else 0.0,
+    "median_sharpe": statistics.median(sharpe) if sharpe else 0.0,
+    "max_drawdown": max(draw) if draw else 0.0,
+}
+json.dump(res, open(sys.argv[2], "w"))
+PY
+fi
+
+copy_item() {
+    local p="$1"
+    if [[ -e "$ROOT/$p" ]]; then
+        local tgt="$TMP_DIR/$(basename "$p")"
+        if [[ -L "$ROOT/$p" ]]; then
+            return
+        fi
+        if [[ -d "$ROOT/$p" ]]; then
+            cp -r "$ROOT/$p" "$tgt"
+        else
+            cp "$ROOT/$p" "$tgt"
+        fi
+    fi
+}
+
+copy_item last_3_codex_diffs
+copy_item vault_export.json
+copy_item config.yaml
+copy_item .env
+copy_item sim/results
+copy_item logs/scoreboard.json
+copy_item "$TTL_FILE"
+copy_item "$TMP_DIR/meta.json"
+copy_item "$TMP_DIR/capital_gate.json"
+
+if [[ $DRY -eq 1 ]]; then
+    echo "DRY RUN: would create $EXPORT_DIR/$ARCHIVE" && ls -R "$TMP_DIR"
+    exit 0
+fi
+
+mkdir -p "$EXPORT_DIR"
+
+tar -czf "$EXPORT_DIR/$ARCHIVE" -C "$TMP_DIR" .
+echo "Export created at $EXPORT_DIR/$ARCHIVE"

--- a/tests/test_export_project_state_sh.py
+++ b/tests/test_export_project_state_sh.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+from pathlib import Path
+import tarfile
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "export_project_state.sh"
+
+
+def run_script(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)] + args,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+
+def test_full_export(tmp_path: Path) -> None:
+    (tmp_path / "last_3_codex_diffs").mkdir()
+    (tmp_path / "last_3_codex_diffs" / "patch.json").write_text("p")
+    (tmp_path / "vault_export.json").write_text("{}")
+    (tmp_path / "sim" / "results").mkdir(parents=True)
+    (tmp_path / "sim" / "results" / "r.txt").write_text("r")
+    strat_dir = tmp_path / "strategies" / "demo"
+    strat_dir.mkdir(parents=True)
+    strat_dir.joinpath("strategy.py").write_text('"""\nttl_hours: 24\n"""')
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "scoreboard.json").write_text('[{"pnl":1,"sharpe":2,"drawdown":0.1}]')
+
+    env = os.environ.copy()
+    env.update({
+        "EXPORT_DIR": str(tmp_path / "export"),
+        "PWD": str(tmp_path)
+    })
+    os.chdir(tmp_path)
+
+    run_script([], env)
+
+    archives = list((tmp_path / "export").glob("drp_export_FULL_*.tar.gz"))
+    assert len(archives) == 1
+    with tarfile.open(archives[0], "r:gz") as tar:
+        names = tar.getnames()
+        assert "./meta.json" in names
+        assert "./strategy_ttl.txt" in names
+        assert "./last_3_codex_diffs/patch.json" in names
+        assert "./vault_export.json" in names
+        assert "./results/r.txt" in names
+        assert "./scoreboard.json" in names
+
+
+def test_dry_run(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.update({"EXPORT_DIR": str(tmp_path / "export"), "PWD": str(tmp_path)})
+    os.chdir(tmp_path)
+    result = run_script(["--dry-run"], env)
+    assert "DRY RUN" in result.stdout
+    assert not (tmp_path / "export").exists()


### PR DESCRIPTION
## Summary
- implement `export_project_state.sh` to snapshot git sha, codex diffs, vault secrets, sim results and capital metrics
- add CI step to run the export script in dry-run mode
- include strategy TTL parsing and capital metrics summary
- patch chaos scheduler for mypy clean
- test project state export script

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini agents ai core strategies infra scripts`
- `pytest tests/test_export_project_state_sh.py::test_full_export tests/test_export_project_state_sh.py::test_dry_run -v`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6845f5f3ccd4832c9d498343f25a6239