### PR TITLE
Implement AI voting quorum

### DIFF
--- a/ai/mutator/mutator.py
+++ b/ai/mutator/mutator.py
@@ -29,6 +29,7 @@ from ai.mutation_log import log_mutation
 from .score import score_strategies
 from .prune import prune_strategies
 from agents.founder_gate import founder_approved
+from ai.voting import get_votes
 
 LOGGER = StructuredLogger("mutator")
 
@@ -63,6 +64,7 @@ def _log_codex_diff(strategy_id: str, prompt: str) -> None:
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "patch_id": patch_id,
         "prompt_hash": prompt_hash,
+        "votes": get_votes(strategy_id, patch_id),
     }
 
     entries = []
@@ -77,6 +79,13 @@ def _log_codex_diff(strategy_id: str, prompt: str) -> None:
     with file.open("w") as fh:
         for e in entries:
             fh.write(json.dumps(e) + "\n")
+    log_mutation(
+        "codex_diff",
+        strategy_id=strategy_id,
+        patch_id=patch_id,
+        prompt_hash=prompt_hash,
+        votes=entry["votes"],
+    )
 
 
 class Mutator:

--- a/ai/promote.py
+++ b/ai/promote.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from core.logger import StructuredLogger, log_error
+from ai.voting import quorum_met
 from agents.capital_lock import CapitalLock
 from agents.ops_agent import OpsAgent
 from agents.drp_agent import DRPAgent
@@ -62,6 +63,15 @@ def promote_strategy(
                 trace_id=trace_id,
             )
             return False
+    patch_hash = os.getenv("PATCH_HASH", "unknown")
+    if not quorum_met(src.name, patch_hash):
+        LOGGER.log(
+            "promotion_blocked",
+            strategy_id=src.name,
+            risk_level="high",
+            trace_id=trace_id,
+        )
+        return False
     try:
         if dst.exists():
             shutil.rmtree(dst)

--- a/ai/voting.py
+++ b/ai/voting.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+from core.logger import StructuredLogger
+
+def _votes_dir() -> Path:
+    path = Path(os.getenv("AI_VOTES_DIR", "telemetry/ai_votes"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+LOGGER = StructuredLogger("voting")
+
+EXPECTED_AGENTS = ["Codex_v1", "Codex_v2", "ClaudeSim", "InternalDRL"]
+
+
+def record_vote(
+    strategy_id: str,
+    patch_hash: str,
+    agent: str,
+    vote: bool,
+    reason: str,
+    timestamp: str,
+) -> None:
+    """Record a vote decision to ``telemetry/ai_votes``."""
+    path = _votes_dir() / f"ai_vote_{timestamp.replace(':', '-')}.json"
+    entry = {
+        "strategy_id": strategy_id,
+        "patch_hash": patch_hash,
+        "agent": agent,
+        "vote": vote,
+        "reason": reason,
+        "timestamp": timestamp,
+    }
+    with path.open("w") as fh:
+        json.dump(entry, fh)
+    LOGGER.log(
+        "vote_recorded",
+        strategy_id=strategy_id,
+        agent=agent,
+        vote=vote,
+        patch_hash=patch_hash,
+        trace_id=os.getenv("TRACE_ID", ""),
+    )
+
+
+def _collect_votes(strategy_id: str, patch_hash: str) -> Dict[str, bool]:
+    votes: Dict[str, bool] = {}
+    for file in _votes_dir().glob("ai_vote_*.json"):
+        try:
+            data = json.loads(file.read_text())
+        except Exception:
+            continue
+        if (
+            data.get("strategy_id") == strategy_id
+            and data.get("patch_hash") == patch_hash
+            and isinstance(data.get("agent"), str)
+        ):
+            votes[data["agent"]] = bool(data.get("vote"))
+    return votes
+
+
+def quorum_met(strategy_id: str, patch_hash: str) -> bool:
+    """Return ``True`` if at least 3 expected agents approve."""
+    votes = _collect_votes(strategy_id, patch_hash)
+    approvals = [agent for agent, v in votes.items() if agent in EXPECTED_AGENTS and v]
+    return len(set(approvals)) >= 3
+
+
+def get_votes(strategy_id: str, patch_hash: str) -> Dict[str, bool]:
+    """Expose recorded votes for ``strategy_id`` and ``patch_hash``."""
+    return _collect_votes(strategy_id, patch_hash)

--- a/tests/test_ai_quorum.py
+++ b/tests/test_ai_quorum.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from ai.voting import record_vote, quorum_met
+
+
+def test_record_vote_and_quorum(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AI_VOTES_DIR", str(tmp_path / "telemetry" / "ai_votes"))
+    timestamp = "2025-01-01T00-00-00"
+    record_vote("s1", "abc", "Codex_v1", True, "ok", timestamp)
+    record_vote("s1", "abc", "Codex_v2", True, "ok", timestamp + "1")
+    record_vote("s1", "abc", "ClaudeSim", True, "ok", timestamp + "2")
+    file = tmp_path / "telemetry" / "ai_votes" / f"ai_vote_{timestamp}.json"
+    assert file.exists()
+    data = json.loads(file.read_text())
+    assert data["vote"] is True
+    assert quorum_met("s1", "abc")
+
+
+def test_quorum_fail(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AI_VOTES_DIR", str(tmp_path / "telemetry" / "ai_votes"))
+    record_vote("s1", "xyz", "Codex_v1", True, "ok", "t1")
+    record_vote("s1", "xyz", "Codex_v2", False, "bad", "t2")
+    record_vote("s1", "xyz", "ClaudeSim", True, "ok", "t3")
+    assert not quorum_met("s1", "xyz")
+

--- a/tests/test_batch_ops.py
+++ b/tests/test_batch_ops.py
@@ -28,6 +28,13 @@ def test_batch_promote_pause(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["FOUNDER_TOKEN"] = "promote:9999999999"
     env["PWD"] = str(tmp_path)
+    env["AI_VOTES_DIR"] = str(tmp_path / "telemetry" / "ai_votes")
+    env["PATCH_HASH"] = "h1"
+    from ai.voting import record_vote
+    os.environ["AI_VOTES_DIR"] = env["AI_VOTES_DIR"]
+    record_vote("s1", "h1", "Codex_v1", True, "ok", "t0")
+    record_vote("s1", "h1", "Codex_v2", True, "ok", "t1")
+    record_vote("s1", "h1", "ClaudeSim", True, "ok", "t2")
     run_script(["promote", "s1", "--source-dir", str(staging.parent), "--dest-dir", str(active.parent)], env)
     assert active.exists()
     run_script(["pause", "s1", "--dest-dir", str(active.parent), "--paused-dir", str(paused)], env)

--- a/tests/test_codex_diff_log.py
+++ b/tests/test_codex_diff_log.py
@@ -43,3 +43,4 @@ def test_codex_diff_logging(monkeypatch, tmp_path):
     assert len(entries) == 3
     assert "patch_id" in entries[-1]
     assert "prompt_hash" in entries[-1]
+    assert "votes" in entries[-1]


### PR DESCRIPTION
## Summary
- add `ai.voting` module for recording votes and quorum checks
- require quorum in `ai.promote.promote_strategy`
- log votes in `_log_codex_diff`
- ensure batch ops test passes by creating votes
- add new tests for quorum logic

## Testing
- `ruff check .`
- `mypy --strict ai tests/test_ai_quorum.py tests/test_batch_ops.py`
- `pytest -q`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_rollup_superbot` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/test.json`

------
https://chatgpt.com/codex/tasks/task_e_6845fa4c8f18832ca9b7c65da8705127