### PR TITLE
Add ai_votes telemetry path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You must use Python 3.11 and activate your virtual environment before running an
 - All modules are self-logging, hot-swappable, and DRP-recoverable.
 - No key access, scaling, or mutation without founder sign-off.
 - One-command audit export available (`scripts/export_state.sh`).
+- AI consensus vote logs are stored in `telemetry/ai_votes/`.
 
 ---
 

--- a/scripts/export_state.sh
+++ b/scripts/export_state.sh
@@ -55,7 +55,7 @@ fi
 # export mode
 ITEMS=()
 ROOT_DIR="$(pwd)"
-for d in logs state active keys; do
+for d in logs state active keys telemetry/ai_votes; do
     if [[ -e "$d" ]]; then
         real="$(realpath "$d")"
         case "$real" in

--- a/telemetry/ai_votes/README.md
+++ b/telemetry/ai_votes/README.md
@@ -1,0 +1,19 @@
+# AI Vote Logs
+
+This directory stores JSON vote logs produced by the automated consensus agents.
+Each file is named `ai_vote_<timestamp>.json` and contains a single JSON object:
+
+```json
+{
+  "strategy_id": "my_strategy",
+  "patch_hash": "abc123",
+  "agent": "Codex_v1",
+  "vote": true,
+  "reason": "pass",
+  "timestamp": "2025-01-01T00-00-00"
+}
+```
+
+The environment variable `AI_VOTES_DIR` controls the location of these logs.
+By default it points to `telemetry/ai_votes`. Tools read this directory to
+check if quorum has been met before promoting a patch.


### PR DESCRIPTION
## Summary
- add telemetry/ai_votes README describing vote log format
- include telemetry/ai_votes in DRP export archives
- document telemetry path in README

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `PYTHONPATH=. python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json`

------
https://chatgpt.com/codex/tasks/task_e_6845fe82a8f0832c942d3a020290115f