### PR TITLE
Log ensemble votes for promotions

### DIFF
--- a/tests/test_codex_diff_log.py
+++ b/tests/test_codex_diff_log.py
@@ -44,3 +44,4 @@ def test_codex_diff_logging(monkeypatch, tmp_path):
     assert "patch_id" in entries[-1]
     assert "prompt_hash" in entries[-1]
     assert "votes" in entries[-1]
+    assert "vote_summary" in entries[-1]

--- a/tests/test_promotion_logging.py
+++ b/tests/test_promotion_logging.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import importlib
+from ai import promote as promote_mod
+from ai.voting import record_vote
+
+
+def test_promotion_logs_votes(monkeypatch, tmp_path: Path) -> None:
+    log_file = tmp_path / "mutation_log.json"
+    monkeypatch.setenv("MUTATION_LOG", str(log_file))
+    monkeypatch.setenv("FOUNDER_TOKEN", "promote:9999999999")
+    monkeypatch.setenv("AI_VOTES_DIR", str(tmp_path / "votes"))
+    patch_hash = "abc"
+    monkeypatch.setenv("PATCH_HASH", patch_hash)
+    import ai.mutation_log as mlog
+    importlib.reload(mlog)
+    importlib.reload(promote_mod)
+    record_vote("s1", patch_hash, "Codex_v1", True, "ok", "t1")
+    record_vote("s1", patch_hash, "Codex_v2", True, "ok", "t2")
+    record_vote("s1", patch_hash, "ClaudeSim", True, "ok", "t3")
+
+    src = tmp_path / "staging" / "s1"
+    dst = tmp_path / "active" / "s1"
+    src.mkdir(parents=True)
+    (src / "file.txt").write_text("x")
+
+    assert promote_mod.promote_strategy(src, dst, approved=True, trace_id="t")
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert entries[-1]["event"] == "promotion"
+    assert entries[-1]["vote_summary"]["quorum"] is True


### PR DESCRIPTION
## Summary
- extend `_log_codex_diff` to store vote summaries
- log vote summaries for each promotion attempt
- ensure codex diff logs include `vote_summary`
- test promotion logging

## Testing
- `ruff check .`
- `mypy --strict` *(fails: missing stub packages)*
- `pytest -v tests/test_promotion_logging.py`
- `pytest -v` *(fails: ModuleNotFoundError: yaml)*
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError: strategies)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError: core)*

------
https://chatgpt.com/codex/tasks/task_e_6845ffa83c60832cb9a009aba0c23c55