### PR TITLE
Add promote_strategy quorum test

### DIFF
--- a/tests/test_ai_quorum.py
+++ b/tests/test_ai_quorum.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from ai.promote import promote_strategy
 from ai.voting import record_vote, quorum_met
 
 
@@ -25,4 +26,42 @@ def test_quorum_fail(monkeypatch, tmp_path: Path) -> None:
     record_vote("s1", "xyz", "Codex_v2", False, "bad", "t2")
     record_vote("s1", "xyz", "ClaudeSim", True, "ok", "t3")
     assert not quorum_met("s1", "xyz")
+
+
+def test_promote_strategy_quorum(monkeypatch, tmp_path: Path) -> None:
+    """promote_strategy should respect quorum rules."""
+    monkeypatch.chdir(tmp_path)
+    votes = tmp_path / "telemetry" / "ai_votes"
+    votes.mkdir(parents=True)
+    monkeypatch.setenv("AI_VOTES_DIR", str(votes))
+    monkeypatch.setenv("FOUNDER_TOKEN", "promote:9999999999")
+    patch_hash = "abc"
+    monkeypatch.setenv("PATCH_HASH", patch_hash)
+
+    src = tmp_path / "staging" / "s1"
+    dst = tmp_path / "active" / "s1"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+
+    def write_vote(agent: str, vote: bool, ts: str) -> None:
+        (votes / f"ai_vote_{ts}.json").write_text(
+            json.dumps({
+                "strategy_id": "s1",
+                "patch_hash": patch_hash,
+                "agent": agent,
+                "vote": vote,
+                "reason": "ok",
+                "timestamp": ts,
+            })
+        )
+
+    write_vote("Codex_v1", True, "t1")
+    write_vote("Codex_v2", False, "t2")
+    write_vote("ClaudeSim", True, "t3")
+
+    assert not promote_strategy(src, dst, approved=True)
+
+    write_vote("InternalDRL", True, "t4")
+
+    assert promote_strategy(src, dst, approved=True)
 


### PR DESCRIPTION
## Summary
- extend existing ai quorum tests to ensure promote_strategy checks vote quorum
- create manual vote files to simulate insufficient and sufficient approvals

## Testing
- `ruff check tests/test_ai_quorum.py`
- `mypy --strict tests/test_ai_quorum.py`
- `pytest -k test_ai_quorum -vv`
- `pytest -v`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684610d2b040832caa606bb2ef4cc714