### PR TITLE
Implement async run loops with DRP snapshots

### DIFF
--- a/strategies/cross_rollup_superbot/strategy.py
+++ b/strategies/cross_rollup_superbot/strategy.py
@@ -47,6 +47,7 @@ from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 import time
+import subprocess
 try:
     from prometheus_client import Counter, Histogram, start_http_server
 except Exception:  # pragma: no cover - optional
@@ -425,7 +426,7 @@ async def run(
     test_mode: bool = False,
     **kwargs: Any,
 ) -> None:
-    """Execute :meth:`CrossRollupSuperbot.run_once` with latency tracking."""
+    """Run the strategy in a monitored loop."""
 
     if block_number is not None:
         os.environ["BLOCK_NUMBER"] = str(block_number)
@@ -435,19 +436,62 @@ async def run(
         os.environ["TEST_MODE"] = "1"
 
     strategy = CrossRollupSuperbot({}, {}, **kwargs)
-    start = time.monotonic()
-    strategy.run_once()
-    latency = time.monotonic() - start
-    LOG.log(
-        "run_latency",
-        strategy_id=EDGE_SCHEMA["strategy_id"],
-        mutation_id=os.getenv("MUTATION_ID", "dev"),
-        risk_level="low",
-        latency=latency,
-        block=block_number,
-        chain_id=chain_id,
-        test_mode=test_mode,
-    )
+
+    error_limit = int(os.getenv("ARB_ERROR_LIMIT", "3"))
+    latency_threshold = float(os.getenv("ARB_LATENCY_THRESHOLD", "30"))
+    errors = 0
+    total_latency = 0.0
+    runs = 0
+
+    def _snapshot_state() -> None:
+        cmd = ["bash", "scripts/export_state.sh"]
+        env = os.environ.copy()
+        env["EXPORT_DIR"] = "/telemetry/drp"
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except FileNotFoundError:
+            log_error(EDGE_SCHEMA["strategy_id"], "export_state.sh missing", event="snapshot_fail")
+        except subprocess.CalledProcessError as exc:
+            log_error(EDGE_SCHEMA["strategy_id"], f"snapshot fail: {exc.stderr}", event="snapshot_fail")
+
+    while True:
+        if kill_switch_triggered():
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+
+        start = time.monotonic()
+        try:
+            strategy.run_once()
+            errors = 0
+        except Exception as exc:  # pragma: no cover - runtime error
+            log_error(EDGE_SCHEMA["strategy_id"], str(exc), event="run_error")
+            arb_error_count.inc()
+            errors += 1
+        latency = time.monotonic() - start
+        arb_latency.observe(latency)
+        total_latency += latency
+        runs += 1
+        avg_latency = total_latency / runs
+
+        LOG.log(
+            "run_latency",
+            strategy_id=EDGE_SCHEMA["strategy_id"],
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            latency=latency,
+            block=block_number,
+            chain_id=chain_id,
+            test_mode=test_mode,
+        )
+
+        if avg_latency > latency_threshold or errors > error_limit:
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+        if test_mode:
+            break
+        await asyncio.sleep(float(os.getenv("RUN_INTERVAL", "1")))
 
 
 if __name__ == "__main__":

--- a/strategies/l3_app_rollup_mev/strategy.py
+++ b/strategies/l3_app_rollup_mev/strategy.py
@@ -42,6 +42,7 @@ from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 from agents.capital_lock import CapitalLock
 import time
+import subprocess
 try:
     from prometheus_client import Counter, Histogram, start_http_server
 except Exception:  # pragma: no cover - optional
@@ -466,7 +467,7 @@ async def run(
     test_mode: bool = False,
     **kwargs: Any,
 ) -> None:
-    """Execute :meth:`L3AppRollupMEV.run_once` with async launcher."""
+    """Run the strategy in a monitored loop."""
 
     if block_number is not None:
         os.environ["BLOCK_NUMBER"] = str(block_number)
@@ -476,19 +477,62 @@ async def run(
         os.environ["TEST_MODE"] = "1"
 
     strategy = L3AppRollupMEV({}, {}, **kwargs)
-    start = time.monotonic()
-    strategy.run_once()
-    latency = time.monotonic() - start
-    LOG.log(
-        "run_latency",
-        strategy_id=EDGE_SCHEMA["strategy_id"],
-        mutation_id=os.getenv("MUTATION_ID", "dev"),
-        risk_level="low",
-        latency=latency,
-        block=block_number,
-        chain_id=chain_id,
-        test_mode=test_mode,
-    )
+
+    error_limit = int(os.getenv("ARB_ERROR_LIMIT", "3"))
+    latency_threshold = float(os.getenv("ARB_LATENCY_THRESHOLD", "30"))
+    errors = 0
+    total_latency = 0.0
+    runs = 0
+
+    def _snapshot_state() -> None:
+        cmd = ["bash", "scripts/export_state.sh"]
+        env = os.environ.copy()
+        env["EXPORT_DIR"] = "/telemetry/drp"
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except FileNotFoundError:
+            log_error(EDGE_SCHEMA["strategy_id"], "export_state.sh missing", event="snapshot_fail")
+        except subprocess.CalledProcessError as exc:
+            log_error(EDGE_SCHEMA["strategy_id"], f"snapshot fail: {exc.stderr}", event="snapshot_fail")
+
+    while True:
+        if kill_switch_triggered():
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+
+        start = time.monotonic()
+        try:
+            strategy.run_once()
+            errors = 0
+        except Exception as exc:  # pragma: no cover - runtime error
+            log_error(EDGE_SCHEMA["strategy_id"], str(exc), event="run_error")
+            arb_error_count.inc()
+            errors += 1
+        latency = time.monotonic() - start
+        arb_latency.observe(latency)
+        total_latency += latency
+        runs += 1
+        avg_latency = total_latency / runs
+
+        LOG.log(
+            "run_latency",
+            strategy_id=EDGE_SCHEMA["strategy_id"],
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            latency=latency,
+            block=block_number,
+            chain_id=chain_id,
+            test_mode=test_mode,
+        )
+
+        if avg_latency > latency_threshold or errors > error_limit:
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+        if test_mode:
+            break
+        await asyncio.sleep(float(os.getenv("RUN_INTERVAL", "1")))
 
 
 if __name__ == "__main__":

--- a/strategies/l3_sequencer_mev/strategy.py
+++ b/strategies/l3_sequencer_mev/strategy.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, TypedDict, cast
 import yaml
 import time
+import subprocess
 try:
     from prometheus_client import Counter, Histogram, start_http_server
 except Exception:  # pragma: no cover - optional
@@ -429,7 +430,7 @@ async def run(
     test_mode: bool = False,
     **kwargs: Any,
 ) -> None:
-    """Execute :meth:`L3SequencerMEV.run_once` with latency tracking."""
+    """Run the strategy in a monitored loop."""
 
     if block_number is not None:
         os.environ["BLOCK_NUMBER"] = str(block_number)
@@ -439,19 +440,62 @@ async def run(
         os.environ["TEST_MODE"] = "1"
 
     strategy = L3SequencerMEV({}, **kwargs)
-    start = time.monotonic()
-    strategy.run_once()
-    latency = time.monotonic() - start
-    LOG.log(
-        "run_latency",
-        strategy_id=EDGE_SCHEMA["strategy_id"],
-        mutation_id=os.getenv("MUTATION_ID", "dev"),
-        risk_level="low",
-        latency=latency,
-        block=block_number,
-        chain_id=chain_id,
-        test_mode=test_mode,
-    )
+
+    error_limit = int(os.getenv("ARB_ERROR_LIMIT", "3"))
+    latency_threshold = float(os.getenv("ARB_LATENCY_THRESHOLD", "30"))
+    errors = 0
+    total_latency = 0.0
+    runs = 0
+
+    def _snapshot_state() -> None:
+        cmd = ["bash", "scripts/export_state.sh"]
+        env = os.environ.copy()
+        env["EXPORT_DIR"] = "/telemetry/drp"
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except FileNotFoundError:
+            log_error(EDGE_SCHEMA["strategy_id"], "export_state.sh missing", event="snapshot_fail")
+        except subprocess.CalledProcessError as exc:
+            log_error(EDGE_SCHEMA["strategy_id"], f"snapshot fail: {exc.stderr}", event="snapshot_fail")
+
+    while True:
+        if kill_switch_triggered():
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+
+        start = time.monotonic()
+        try:
+            strategy.run_once()
+            errors = 0
+        except Exception as exc:  # pragma: no cover - runtime error
+            log_error(EDGE_SCHEMA["strategy_id"], str(exc), event="run_error")
+            arb_error_count.inc()
+            errors += 1
+        latency = time.monotonic() - start
+        arb_latency.observe(latency)
+        total_latency += latency
+        runs += 1
+        avg_latency = total_latency / runs
+
+        LOG.log(
+            "run_latency",
+            strategy_id=EDGE_SCHEMA["strategy_id"],
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            latency=latency,
+            block=block_number,
+            chain_id=chain_id,
+            test_mode=test_mode,
+        )
+
+        if avg_latency > latency_threshold or errors > error_limit:
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+        if test_mode:
+            break
+        await asyncio.sleep(float(os.getenv("RUN_INTERVAL", "1")))
 
 
 if __name__ == "__main__":

--- a/strategies/nft_liquidation/strategy.py
+++ b/strategies/nft_liquidation/strategy.py
@@ -38,6 +38,7 @@ from core.tx_engine.builder import HexBytes, TransactionBuilder
 from core.tx_engine.nonce_manager import NonceManager, get_shared_nonce_manager
 from core.tx_engine.kill_switch import kill_switch_triggered, record_kill_event
 import time
+import subprocess
 from agents.capital_lock import CapitalLock
 try:
     from prometheus_client import Counter, Histogram, start_http_server
@@ -328,7 +329,7 @@ async def run(
     test_mode: bool = False,
     **kwargs: Any,
 ) -> None:
-    """Execute :meth:`NFTLiquidationMEV.run_once` with latency tracking."""
+    """Run the strategy in a monitored loop."""
 
     if block_number is not None:
         os.environ["BLOCK_NUMBER"] = str(block_number)
@@ -338,19 +339,62 @@ async def run(
         os.environ["TEST_MODE"] = "1"
 
     strategy = NFTLiquidationMEV({}, **kwargs)
-    start = time.monotonic()
-    strategy.run_once()
-    latency = time.monotonic() - start
-    LOG.log(
-        "run_latency",
-        strategy_id=EDGE_SCHEMA["strategy_id"],
-        mutation_id=os.getenv("MUTATION_ID", "dev"),
-        risk_level="low",
-        latency=latency,
-        block=block_number,
-        chain_id=chain_id,
-        test_mode=test_mode,
-    )
+
+    error_limit = int(os.getenv("ARB_ERROR_LIMIT", "3"))
+    latency_threshold = float(os.getenv("ARB_LATENCY_THRESHOLD", "30"))
+    errors = 0
+    total_latency = 0.0
+    runs = 0
+
+    def _snapshot_state() -> None:
+        cmd = ["bash", "scripts/export_state.sh"]
+        env = os.environ.copy()
+        env["EXPORT_DIR"] = "/telemetry/drp"
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except FileNotFoundError:
+            log_error(EDGE_SCHEMA["strategy_id"], "export_state.sh missing", event="snapshot_fail")
+        except subprocess.CalledProcessError as exc:
+            log_error(EDGE_SCHEMA["strategy_id"], f"snapshot fail: {exc.stderr}", event="snapshot_fail")
+
+    while True:
+        if kill_switch_triggered():
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+
+        start = time.monotonic()
+        try:
+            strategy.run_once()
+            errors = 0
+        except Exception as exc:  # pragma: no cover - runtime error
+            log_error(EDGE_SCHEMA["strategy_id"], str(exc), event="run_error")
+            arb_error_count.inc()
+            errors += 1
+        latency = time.monotonic() - start
+        arb_latency.observe(latency)
+        total_latency += latency
+        runs += 1
+        avg_latency = total_latency / runs
+
+        LOG.log(
+            "run_latency",
+            strategy_id=EDGE_SCHEMA["strategy_id"],
+            mutation_id=os.getenv("MUTATION_ID", "dev"),
+            risk_level="low",
+            latency=latency,
+            block=block_number,
+            chain_id=chain_id,
+            test_mode=test_mode,
+        )
+
+        if avg_latency > latency_threshold or errors > error_limit:
+            record_kill_event(EDGE_SCHEMA["strategy_id"])
+            _snapshot_state()
+            sys.exit(137)
+        if test_mode:
+            break
+        await asyncio.sleep(float(os.getenv("RUN_INTERVAL", "1")))
 
 
 if __name__ == "__main__":

--- a/tests/test_run_kill.py
+++ b/tests/test_run_kill.py
@@ -1,13 +1,13 @@
 import asyncio
 import importlib
-from typing import Any
+from typing import Any, List, Tuple
 
 import pytest
 
 pytest.importorskip("strategies.cross_domain_arb.strategy")
 
 
-def _setup_failure(monkeypatch: pytest.MonkeyPatch) -> Any:
+def _setup_failure(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, List[Tuple[list[str], str | None]]]:
     """Patch strategy to raise a runtime error."""
     mod = importlib.import_module("strategies.cross_domain_arb.strategy")
 
@@ -21,11 +21,20 @@ def _setup_failure(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(mod, "CrossDomainArb", Dummy)
     monkeypatch.setenv("ARB_ERROR_LIMIT", "0")
     monkeypatch.setenv("ARB_LATENCY_THRESHOLD", "100")
-    return mod
+
+    calls: List[Tuple[list[str], str | None]] = []
+
+    def fake_run(cmd: list[str], *args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub
+        env = kwargs.get("env", {})
+        calls.append((cmd, env.get("EXPORT_DIR")))
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    return mod, calls
 
 
 def test_run_kill(monkeypatch: pytest.MonkeyPatch) -> None:
-    mod = _setup_failure(monkeypatch)
+    mod, calls = _setup_failure(monkeypatch)
     called: list[str] = []
     monkeypatch.setattr(mod, "record_kill_event", lambda origin: called.append(origin))
 
@@ -34,10 +43,12 @@ def test_run_kill(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert se.value.code == 137
     assert called and called[0] == mod.STRATEGY_ID
+    assert calls and calls[0][0][1].endswith("export_state.sh")
+    assert calls[0][1] == "/telemetry/drp"
 
 
 def test_run_kill_error_counter(monkeypatch: pytest.MonkeyPatch) -> None:
-    mod = _setup_failure(monkeypatch)
+    mod, _ = _setup_failure(monkeypatch)
     called: list[str] = []
     monkeypatch.setattr(mod, "record_kill_event", lambda origin: called.append(origin))
 


### PR DESCRIPTION
## Summary
- make each strategy run loop asynchronous with latency/error tracking
- export DRP state on threshold breach before exiting
- record kill switch events at loop level
- update run_kill tests for DRP snapshot logic

## Testing
- `pytest tests/test_run_kill.py -vv`
- `pytest -q` *(fails: Port 8000 already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68462da2350c832ca7f00d86347034e3