### PR TITLE
Enable strategy-specific fork sims

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,14 +42,22 @@ jobs:
           sleep 2
           curl -f http://localhost:8001/metrics
           kill $PID
-      - name: Fork simulation
-        run: bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
+      - name: Fork simulation cross_rollup_superbot
+        run: bash scripts/simulate_fork.sh --strategy=cross_rollup_superbot
+      - name: Fork simulation l3_app_rollup_mev
+        run: bash scripts/simulate_fork.sh --strategy=l3_app_rollup_mev
+      - name: Fork simulation l3_sequencer_mev
+        run: bash scripts/simulate_fork.sh --strategy=l3_sequencer_mev
+      - name: Fork simulation nft_liquidation
+        run: bash scripts/simulate_fork.sh --strategy=nft_liquidation
+      - name: Fork simulation rwa_settlement
+        run: bash scripts/simulate_fork.sh --strategy=rwa_settlement
       - name: DRP dry run
         run: bash scripts/export_state.sh --dry-run
       - name: Project audit export
         run: bash scripts/export_project_state.sh --dry-run
       - name: Offline audit
-        run: python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+        run: python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json
       - name: Chaos drill
         run: python3.11 infra/sim_harness/chaos_drill.py
       - name: Tag canary
@@ -61,9 +69,13 @@ jobs:
           ruff check .
           mypy --strict .
           pytest -v
-          bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb
+          bash scripts/simulate_fork.sh --strategy=cross_rollup_superbot
+          bash scripts/simulate_fork.sh --strategy=l3_app_rollup_mev
+          bash scripts/simulate_fork.sh --strategy=l3_sequencer_mev
+          bash scripts/simulate_fork.sh --strategy=nft_liquidation
+          bash scripts/simulate_fork.sh --strategy=rwa_settlement
           bash scripts/export_state.sh --dry-run
-          python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_domain_arb.json
+          python3.11 ai/audit_agent.py --mode=offline --logs logs/cross_rollup_superbot.json
       - name: Check gates
         run: python3.11 agents/check_gates.py
       - name: Promote

--- a/scripts/simulate_fork.sh
+++ b/scripts/simulate_fork.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # Run the fork simulation harness for a given strategy.
-# Usage: scripts/simulate_fork.sh --target=strategies/<module>
+# Usage: scripts/simulate_fork.sh [--target=strategies/<module>] [--strategy=<name>]
+#        scripts/simulate_fork.sh <name>
 
 set -euo pipefail
 
-TARGET="strategies/cross_domain_arb"
+TARGET=""
+STRATEGY=""
 
 for arg in "$@"; do
     case $arg in
@@ -13,16 +15,34 @@ for arg in "$@"; do
             TARGET="${arg#*=}"
             shift
             ;;
+        --strategy=*)
+            STRATEGY="${arg#*=}"
+            shift
+            ;;
         *)
-            echo "Usage: $0 --target=strategies/<module>" >&2
-            exit 1
+            if [[ -z "$TARGET" && -z "$STRATEGY" ]]; then
+                STRATEGY="$arg"
+            else
+                echo "Usage: $0 [--target=strategies/<module>] [--strategy=<name>]" >&2
+                exit 1
+            fi
             ;;
     esac
 done
 
-NAME="$(basename "$TARGET")"
+if [[ -n "$STRATEGY" ]]; then
+    NAME="$STRATEGY"
+elif [[ -n "$TARGET" ]]; then
+    NAME="$(basename "$TARGET")"
+else
+    NAME="cross_domain_arb"
+fi
 if [[ "$NAME" == "cross_domain_arb" ]]; then
     NAME="cross_arb"
+elif [[ "$NAME" == "cross_rollup_superbot" ]]; then
+    NAME="cross_rollup_superbot"
+elif [[ "$NAME" == "l3_app_rollup_mev" ]]; then
+    NAME="l3_app_rollup_mev"
 elif [[ "$NAME" == "l3_sequencer_mev" ]]; then
     NAME="l3_sequencer_mev"
 elif [[ "$NAME" == "nft_liquidation" ]]; then
@@ -33,7 +53,7 @@ fi
 SCRIPT="infra/sim_harness/fork_sim_${NAME}.py"
 
 if [[ ! -f "$SCRIPT" ]]; then
-    echo "Unknown target: $TARGET" >&2
+    echo "Unknown strategy: $NAME" >&2
     exit 1
 fi
 

--- a/tests/test_fork_harnesses.py
+++ b/tests/test_fork_harnesses.py
@@ -1,0 +1,63 @@
+import importlib
+import types
+
+import pytest
+
+
+class DummyStrat:
+    def __init__(self, *a, **k):
+        pass
+
+    def run_once(self):
+        return {"opportunity": True, "profit_eth": 1.0}
+
+
+class DummyEth:
+    block_number = 20000000
+
+
+class DummyWeb3:
+    class HTTPProvider:  # pragma: no cover - dummy
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+    def __init__(self, *_a, **_k):
+        self.eth = DummyEth()
+        self.middleware_onion = types.SimpleNamespace(add=lambda *_a, **_k: None)
+
+
+HARNESS = {
+    "infra.sim_harness.fork_sim_cross_rollup_superbot": "CrossRollupSuperbot",
+    "infra.sim_harness.fork_sim_l3_app_rollup_mev": "L3AppRollupMEV",
+    "infra.sim_harness.fork_sim_l3_sequencer_mev": "L3SequencerMEV",
+    "infra.sim_harness.fork_sim_nft_liquidation": "NFTLiquidationMEV",
+    "infra.sim_harness.fork_sim_rwa_settlement": "RWASettlementMEV",
+}
+
+
+@pytest.mark.parametrize("module_path,strat_cls", HARNESS.items())
+def test_harness_runs(tmp_path, monkeypatch, module_path, strat_cls):
+    class DummyMetric:
+        def __init__(self, *a, **k):
+            pass
+
+        def inc(self, *a, **k):
+            pass
+
+        def observe(self, *a, **k):
+            pass
+
+    import prometheus_client
+    monkeypatch.setattr(prometheus_client, "Counter", DummyMetric, raising=False)
+    monkeypatch.setattr(prometheus_client, "Histogram", DummyMetric, raising=False)
+    monkeypatch.setattr(prometheus_client, "start_http_server", lambda *_a, **_k: None, raising=False)
+    module = importlib.import_module(module_path)
+    monkeypatch.setattr(module, strat_cls, DummyStrat, raising=False)
+    monkeypatch.setattr(module, "Web3", DummyWeb3, raising=False)
+    if hasattr(module, "geth_poa_middleware"):
+        monkeypatch.setattr(module, "geth_poa_middleware", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(module.time, "sleep", lambda *_a, **_k: None)
+    (tmp_path / "logs").mkdir()
+    monkeypatch.chdir(tmp_path)
+    module.main()
+    assert (tmp_path / "logs" / "sim_complete.txt").exists()


### PR DESCRIPTION
## Summary
- extend `simulate_fork.sh` to accept strategy names
- run fork sims for all strategies in CI
- add harness tests for each strategy

## Testing
- `ruff check tests/test_fork_harnesses.py`
- `pytest tests/test_fork_harnesses.py -v`
- `pytest -v` *(fails: Duplicated timeseries in CollectorRegistry)*
- `foundry test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684632eb0a1c832c82aeabf209ac1315