### PR TITLE
Add DRP auto rollback service

### DIFF
--- a/agents/drp_agent.py
+++ b/agents/drp_agent.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+import subprocess
 
 from core.logger import StructuredLogger
 from .agent_registry import set_value
@@ -15,6 +18,15 @@ class DRPAgent:
     """Simple DRP health tracker."""
 
     ready: bool = True
+
+    # --------------------------------------------------------------
+    def _latest_export_time(self, export_dir: str = "export") -> datetime | None:
+        """Return timestamp of the most recent DRP export in ``export_dir``."""
+        path = Path(export_dir)
+        files = sorted(path.glob("drp_export_*"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if not files:
+            return None
+        return datetime.utcfromtimestamp(files[0].stat().st_mtime)
 
     # --------------------------------------------------------------
     def record_export(self, success: bool) -> None:
@@ -35,3 +47,22 @@ class DRPAgent:
     def is_ready(self) -> bool:
         """Return True if DRP is healthy."""
         return self.ready
+
+    # --------------------------------------------------------------
+    def auto_recover(self, *, export_dir: str = "export", timeout: int = 3600) -> None:
+        """Trigger rollback if DRP has been unhealthy for longer than ``timeout`` seconds."""
+        ts = self._latest_export_time(export_dir)
+        if ts is None or self.ready:
+            return
+        if datetime.utcnow() - ts > timedelta(seconds=timeout):
+            try:
+                subprocess.run([
+                    "bash",
+                    "scripts/rollback.sh",
+                    f"--export-dir={export_dir}",
+                ], check=True)
+                LOGGER.log("auto_rollback", risk_level="high")
+                self.ready = True
+                set_value("drp_ready", True)
+            except Exception as exc:  # pragma: no cover - runtime failures
+                LOGGER.log("auto_rollback_fail", risk_level="high", error=str(exc))

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -153,6 +153,7 @@ class StrategyOrchestrator:
 
         ok = self._snapshot_state()
         self.drp_agent.record_export(ok)
+        self.drp_agent.auto_recover()
         LOGGER.log("iteration_complete", risk_level="low")
         return True
 


### PR DESCRIPTION
## Summary
- add `auto_recover` to `DRPAgent` to trigger rollback on stale DRP exports
- call the recovery check from orchestrator
- test that the new recovery logic respects a 1 hour window

## Testing
- `python3.11 -m pytest tests/test_drp_time.py -q`
- `ruff check agents/drp_agent.py tests/test_drp_time.py core/orchestrator.py`
- `mypy --config-file mypy.ini agents/drp_agent.py tests/test_drp_time.py core/orchestrator.py`
- `foundry test` *(fails: command not found)*
- `bash scripts/simulate_fork.sh --target=strategies/cross_domain_arb` *(fails: ModuleNotFoundError)*
- `bash scripts/export_state.sh --dry-run`
- `python3.11 ai/audit_agent.py --mode=offline --logs logs/export_state.json` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684634c28a9c832c92043509d51bdc4e