### PR TITLE
Add simulation configs and scenario tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,16 @@ jobs:
           python3.11 -m pip install -r requirements.txt mypy ruff
       - name: Validate secrets
         run: python3.11 scripts/validate_secrets.py
+      - name: Validate sim configs
+        run: python3.11 scripts/validate_sim_configs.py
       - name: Lint
         run: ruff check .
       - name: Type check
         run: mypy --strict .
       - name: Run tests
         run: pytest -v
+      - name: Run scenario tests
+        run: pytest -v tests/test_sim_scenarios.py
       - name: Metrics endpoint
         run: |
           python3.11 -m core.metrics --port 8001 &

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ logs/
 *.log
 *.json
 !logs/.gitkeep   # (keep folder)
+!sim/configs/*.json
 !infra/grafana/*.json
 !grafana/*.json
 

--- a/scripts/validate_sim_configs.py
+++ b/scripts/validate_sim_configs.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3.11
+"""Validate simulation config JSON files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_KEYS = {"env", "block_number", "strategy_id", "expected_pnl", "max_drawdown", "validators"}
+
+
+def validate_file(path: Path) -> None:
+    data = json.loads(path.read_text())
+    missing = REQUIRED_KEYS - data.keys()
+    if missing:
+        raise SystemExit(f"{path.name}: missing keys {', '.join(sorted(missing))}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    base = Path("sim/configs")
+    for file in base.glob("*.json"):
+        validate_file(file)
+    print("config validation passed")

--- a/sim/configs/mainnet_l1.json
+++ b/sim/configs/mainnet_l1.json
@@ -1,0 +1,8 @@
+{
+  "env": "mainnet",
+  "block_number": 20130231,
+  "strategy_id": "BridgeArb_001",
+  "expected_pnl": ">=gas*1.5",
+  "max_drawdown": "<=7%",
+  "validators": ["sim_result_check.py"]
+}

--- a/sim/configs/optimism_l2.json
+++ b/sim/configs/optimism_l2.json
@@ -1,0 +1,8 @@
+{
+  "env": "optimism",
+  "block_number": 1080932,
+  "strategy_id": "BridgeArb_L2",
+  "expected_pnl": ">=gas*1.5",
+  "max_drawdown": "<=7%",
+  "validators": ["sim_result_check.py"]
+}

--- a/sim/scenarios/replay_bridge_arb.py
+++ b/sim/scenarios/replay_bridge_arb.py
@@ -1,0 +1,26 @@
+"""Scenario: replay bridge arbitrage using fork harness."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from infra.sim_harness import fork_sim_cross_arb
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Replay bridge arbitrage scenario")
+    parser.add_argument(
+        "--config",
+        default=Path(__file__).resolve().parents[1] / "configs" / "mainnet_l1.json",
+        help="Path to scenario config JSON",
+    )
+    args = parser.parse_args()
+    cfg = json.loads(Path(args.config).read_text())
+    os.environ["FORK_BLOCK"] = str(cfg.get("block_number", 19741234))
+    fork_sim_cross_arb.main()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sim/scenarios/sandwich_liquidity_shift.py
+++ b/sim/scenarios/sandwich_liquidity_shift.py
@@ -1,0 +1,26 @@
+"""Scenario: sandwich liquidity shift using cross-rollup harness."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from infra.sim_harness import fork_sim_cross_rollup_superbot
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Simulate sandwich liquidity shift")
+    parser.add_argument(
+        "--config",
+        default=Path(__file__).resolve().parents[1] / "configs" / "optimism_l2.json",
+        help="Path to scenario config JSON",
+    )
+    args = parser.parse_args()
+    cfg = json.loads(Path(args.config).read_text())
+    os.environ["FORK_BLOCK"] = str(cfg.get("block_number", 19741234))
+    fork_sim_cross_rollup_superbot.main()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_sim_configs.py
+++ b/tests/test_sim_configs.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+from scripts.validate_sim_configs import validate_file
+
+
+def test_config_schema():
+    base = Path('sim/configs')
+    for file in base.glob('*.json'):
+        validate_file(file)
+        data = json.loads(file.read_text())
+        assert all(k in data for k in ('env', 'block_number', 'strategy_id', 'expected_pnl', 'max_drawdown', 'validators'))
+
+

--- a/tests/test_sim_scenarios.py
+++ b/tests/test_sim_scenarios.py
@@ -1,0 +1,64 @@
+import importlib
+import types
+
+import pytest
+
+
+class DummyStrat:
+    def __init__(self, *a, **k):
+        pass
+
+    def run_once(self):
+        return {"opportunity": True, "profit_eth": 1.0}
+
+
+class DummyEth:
+    block_number = 20000000
+
+
+class DummyWeb3:
+    class HTTPProvider:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+    def __init__(self, *_a, **_k):
+        self.eth = DummyEth()
+        self.middleware_onion = types.SimpleNamespace(add=lambda *_a, **_k: None)
+
+
+SCENARIOS = {
+    "sim.scenarios.replay_bridge_arb": ("fork_sim_cross_arb", "CrossDomainArb"),
+    "sim.scenarios.sandwich_liquidity_shift": ("fork_sim_cross_rollup_superbot", "CrossRollupSuperbot"),
+}
+
+
+@pytest.mark.parametrize("module_path,harness_name,strat_cls", SCENARIOS.items())
+def test_scenarios_run(tmp_path, monkeypatch, module_path, harness_name, strat_cls):
+    class DummyMetric:
+        def __init__(self, *a, **k):
+            pass
+
+        def inc(self, *a, **k):
+            pass
+
+        def observe(self, *a, **k):
+            pass
+
+    import prometheus_client
+    monkeypatch.setattr(prometheus_client, "Counter", DummyMetric, raising=False)
+    monkeypatch.setattr(prometheus_client, "Histogram", DummyMetric, raising=False)
+    monkeypatch.setattr(prometheus_client, "start_http_server", lambda *_a, **_k: None, raising=False)
+
+    harness = importlib.import_module(f"infra.sim_harness.{harness_name}")
+    monkeypatch.setattr(harness, strat_cls, DummyStrat, raising=False)
+    monkeypatch.setattr(harness, "Web3", DummyWeb3, raising=False)
+    if hasattr(harness, "geth_poa_middleware"):
+        monkeypatch.setattr(harness, "geth_poa_middleware", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(harness.time, "sleep", lambda *_a, **_k: None)
+
+    scenario = importlib.import_module(module_path)
+    (tmp_path / "logs").mkdir()
+    monkeypatch.chdir(tmp_path)
+    scenario.main()
+    assert (tmp_path / "logs" / "sim_complete.txt").exists()
+


### PR DESCRIPTION
## Summary
- add simulation config validation script
- create sim configs and scenario runners
- add tests for new sim configs and scenarios
- update CI workflow to validate configs and run scenario tests
- unignore sim config JSON files

## Testing
- `python3.11 scripts/validate_secrets.py` *(fails: Missing secrets)*
- `python3.11 scripts/load_vault_secrets.py` *(fails: hvac missing)*
- `python3.11 -m pip install -e .`
- `python3.11 -m pip install numpy`
- `python3.11 -m pytest -q` *(fails: ImportError: cannot import name 'record_scoreboard_event')*

------
https://chatgpt.com/codex/tasks/task_e_6846527542bc832c9d2f9880324344f9